### PR TITLE
Fix broken test

### DIFF
--- a/path_data_test.go
+++ b/path_data_test.go
@@ -200,7 +200,7 @@ func TestVersionedKV_Data_Delete(t *testing.T) {
 	}
 
 	var httpResp logical.HTTPResponse
-	err = json.Unmarshal(resp.Data["http_raw_body"].([]byte), &httpResp)
+	err = json.Unmarshal([]byte(resp.Data["http_raw_body"].(string)), &httpResp)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Error received:

```
--- FAIL: TestVersionedKV_Data_Delete (1.00s)
panic: interface conversion: interface {} is string, not []uint8 [recovered]
	panic: interface conversion: interface {} is string, not []uint8
```