### PR TITLE
Include allow_delete_versions in kv/config...

### DIFF
--- a/delete_version_after_test.go
+++ b/delete_version_after_test.go
@@ -131,16 +131,9 @@ func TestDeleteVersionAfter(t *testing.T) {
 			}
 			resp, err = b.HandleRequest(context.Background(), req)
 			wantResponse(t, resp, err)
-			if tt.mount == 0 {
-				got := resp.Data["delete_version_after"]
-				if got != nil {
-					t.Fatalf("mount value: delete_version_after %#v, want no delete_version_after", got)
-				}
-			} else {
-				want, got := tt.mount.String(), resp.Data["delete_version_after"]
-				if want != got {
-					t.Fatalf("want delete_version_after: %v, got %v", want, got)
-				}
+			want, got = tt.mount.String(), resp.Data["delete_version_after"]
+			if want != got {
+				t.Fatalf("want delete_version_after: %v, got %v", want, got)
 			}
 
 			data = map[string]interface{}{

--- a/delete_version_after_test.go
+++ b/delete_version_after_test.go
@@ -131,7 +131,7 @@ func TestDeleteVersionAfter(t *testing.T) {
 			}
 			resp, err = b.HandleRequest(context.Background(), req)
 			wantResponse(t, resp, err)
-			want, got = tt.mount.String(), resp.Data["delete_version_after"]
+			want, got := tt.mount.String(), resp.Data["delete_version_after"]
 			if want != got {
 				t.Fatalf("want delete_version_after: %v, got %v", want, got)
 			}
@@ -156,7 +156,7 @@ func TestDeleteVersionAfter(t *testing.T) {
 			}
 			resp, err = b.HandleRequest(context.Background(), req)
 			wantResponse(t, resp, err)
-			want, got := tt.meta.String(), resp.Data["delete_version_after"]
+			want, got = tt.meta.String(), resp.Data["delete_version_after"]
 			if want != got {
 				t.Fatalf("want delete_version_after: %v, got %v", want, got)
 			}

--- a/path_config.go
+++ b/path_config.go
@@ -62,7 +62,7 @@ func (b *versionedKVBackend) pathConfigRead() framework.OperationFunc {
 
 		rdata := map[string]interface{}{
 			"max_versions": config.MaxVersions,
-			"cas_requred":  config.CasRequired,
+			"cas_required":  config.CasRequired,
 		}
 
 		var deleteVersionAfter time.Duration

--- a/path_config.go
+++ b/path_config.go
@@ -62,7 +62,7 @@ func (b *versionedKVBackend) pathConfigRead() framework.OperationFunc {
 
 		rdata := map[string]interface{}{
 			"max_versions": config.MaxVersions,
-			"cas_required":  config.CasRequired,
+			"cas_required": config.CasRequired,
 		}
 
 		var deleteVersionAfter time.Duration

--- a/path_config.go
+++ b/path_config.go
@@ -62,7 +62,7 @@ func (b *versionedKVBackend) pathConfigRead() framework.OperationFunc {
 
 		rdata := map[string]interface{}{
 			"max_versions": config.MaxVersions,
-			"cas_requred": config.CasRequired,
+			"cas_requred":  config.CasRequired,
 		}
 
 		var deleteVersionAfter time.Duration

--- a/path_config.go
+++ b/path_config.go
@@ -62,7 +62,7 @@ func (b *versionedKVBackend) pathConfigRead() framework.OperationFunc {
 
 		rdata := map[string]interface{}{
 			"max_versions": config.MaxVersions,
-			"cas_required": config.CasRequired,
+			"cas_requred": config.CasRequired,
 		}
 
 		var deleteVersionAfter time.Duration
@@ -71,8 +71,8 @@ func (b *versionedKVBackend) pathConfigRead() framework.OperationFunc {
 			if err != nil {
 				return nil, err
 			}
-			rdata["delete_version_after"] = deleteVersionAfter.String()
 		}
+		rdata["delete_version_after"] = deleteVersionAfter.String()
 
 		return &logical.Response{
 			Data: rdata,

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -70,8 +70,8 @@ func getDuration(t *testing.T, in string) time.Duration {
 
 func TestVersionedKV_Config_DeleteVersionAfter(t *testing.T) {
 	var tests = []struct {
-		ds1, ds2               string
-		want                   time.Duration
+		ds1, ds2 string
+		want     time.Duration
 	}{
 		{"0s", "0s", 0},
 		{"10s", "0s", 0},
@@ -97,9 +97,9 @@ func TestVersionedKV_Config_DeleteVersionAfter(t *testing.T) {
 			resp, err := b.HandleRequest(context.Background(), req)
 			wantResponse(t, resp, err)
 			got := resp.Data["delete_version_after"]
-			if got != nil {
+			if got == nil {
 				t.Logf("resp: %#v", resp)
-				t.Fatalf("default value: delete_version_after %#v, want no delete_version_after", got)
+				t.Fatal("delete_version_after missing, want the default")
 			}
 
 			// set first value
@@ -124,18 +124,10 @@ func TestVersionedKV_Config_DeleteVersionAfter(t *testing.T) {
 			wantResponse(t, resp, err)
 
 			d1 := getDuration(t, tt.ds1)
-			if d1 == 0 {
-				got := resp.Data["delete_version_after"]
-				if got != nil {
-					t.Logf("resp: %#v", resp)
-					t.Fatalf("first value: delete_version_after %#v, want no delete_version_after", got)
-				}
-			} else {
-				want, got := d1.String(), resp.Data["delete_version_after"]
-				if want != got {
-					t.Logf("resp: %#v", resp)
-					t.Fatalf("first value: want delete_version_after: %v, got %v", want, got)
-				}
+			want, got := d1.String(), resp.Data["delete_version_after"]
+			if want != got {
+				t.Logf("resp: %#v", resp)
+				t.Fatalf("first value: want delete_version_after: %v, got %v", want, got)
 			}
 
 			// set second value
@@ -158,7 +150,7 @@ func TestVersionedKV_Config_DeleteVersionAfter(t *testing.T) {
 			}
 			resp, err = b.HandleRequest(context.Background(), req)
 			wantResponse(t, resp, err)
-			want, got := tt.want.String(), resp.Data["delete_version_after"]
+			want, got = tt.want.String(), resp.Data["delete_version_after"]
 			if want != got {
 				t.Logf("resp: %#v", resp)
 				t.Fatalf("second value: want delete_version_after: %v, got %v", want, got)

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -72,15 +72,14 @@ func TestVersionedKV_Config_DeleteVersionAfter(t *testing.T) {
 	var tests = []struct {
 		ds1, ds2               string
 		want                   time.Duration
-		wantDeleteVersionAfter bool
 	}{
-		{"0s", "0s", 0, false},
-		{"10s", "0s", 0, false},
-		{"10s", "20s", 20 * time.Second, true},
-		{"10s", "-1h", disabled, true},
-		{"-1h", "3h", 3 * time.Hour, true},
-		{"-1h", "-1h", disabled, true},
-		{"-1h", "0h", 0, false},
+		{"0s", "0s", 0},
+		{"10s", "0s", 0},
+		{"10s", "20s", 20 * time.Second},
+		{"10s", "-1h", disabled},
+		{"-1h", "3h", 3 * time.Hour},
+		{"-1h", "-1h", disabled},
+		{"-1h", "0h", 0},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -159,18 +158,10 @@ func TestVersionedKV_Config_DeleteVersionAfter(t *testing.T) {
 			}
 			resp, err = b.HandleRequest(context.Background(), req)
 			wantResponse(t, resp, err)
-			if tt.wantDeleteVersionAfter {
-				want, got := tt.want.String(), resp.Data["delete_version_after"]
-				if want != got {
-					t.Logf("resp: %#v", resp)
-					t.Fatalf("second value: want delete_version_after: %v, got %v", want, got)
-				}
-			} else {
-				got := resp.Data["delete_version_after"]
-				if got != nil {
-					t.Logf("resp: %#v", resp)
-					t.Fatalf("second value: delete_version_after %#v, want no delete_version_after", got)
-				}
+			want, got := tt.want.String(), resp.Data["delete_version_after"]
+			if want != got {
+				t.Logf("resp: %#v", resp)
+				t.Fatalf("second value: want delete_version_after: %v, got %v", want, got)
 			}
 		})
 	}


### PR DESCRIPTION
The "allow_delete_versions" kv config value defaults to nil, treated as 0s.  But it is only placed in
the returned read map if it has been overridden.  Instead, always include it, with a default of "0s".

Addresses VLTC-54.