### PR TITLE
Use docker mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 references:
   images:
-    go: &GOLANG_IMAGE circleci/golang:1.12
+    go: &GOLANG_IMAGE docker.mirror.hashicorp.services/circleci/golang:1.12
 
 jobs:
   go-test:


### PR DESCRIPTION
Instead of using dockerhub (which will enforce rate limiting on anonymous image pulls starting Nov 1st), we're moving projects to our mirror at `docker.mirror.hashicorp.services`. LMK if you have any q's, otherwise feel free to approve and merge on your own! 