### PR TITLE
Invalidation callback not registered

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -107,6 +107,7 @@ func VersionedKVFactory(ctx context.Context, conf *logical.BackendConfig) (logic
 	b.Backend = &framework.Backend{
 		BackendType: logical.TypeLogical,
 		Help:        backendHelp,
+		Invalidate:  b.Invalidate,
 
 		PathsSpecial: &logical.Paths{
 			SealWrapStorage: []string{


### PR DESCRIPTION
# Overview
A high level description of the contribution, including:
Who the change affects or is for (stakeholders)?

Enterprise customers

What is the change? 

The invalidation call back was not registered so invalidations coming from active nodes to performance standby where not being processed.

Why is the change needed?

So invalidations of config data can work

How does this change affect the user experience (if at all)?

Users that change configuration will not see it reflected when requesting it from standby nodes.

# Design of Change
How was this change implemented?

Adding the Invalidation call.

