### PR TITLE
Fix Renew operation for KV v1

### DIFF
--- a/passthrough.go
+++ b/passthrough.go
@@ -51,7 +51,7 @@ func LeaseSwitchedPassthroughBackend(ctx context.Context, conf *logical.BackendC
 		},
 
 		Paths: []*framework.Path{
-			&framework.Path{
+			{
 				Pattern: framework.MatchAllRegex("path"),
 
 				Fields: map[string]*framework.FieldSchema{
@@ -76,10 +76,13 @@ func LeaseSwitchedPassthroughBackend(ctx context.Context, conf *logical.BackendC
 			},
 		},
 		Secrets: []*framework.Secret{
-			&framework.Secret{
+			{
 				Type: "kv",
 
-				Renew: b.handleRead(),
+				Renew: func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+					// This is a no-op
+					return nil, nil
+				},
 				Revoke: func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 					// This is a no-op
 					return nil, nil
@@ -89,7 +92,7 @@ func LeaseSwitchedPassthroughBackend(ctx context.Context, conf *logical.BackendC
 	}
 
 	if conf == nil {
-		return nil, fmt.Errorf("Configuation passed into backend is nil")
+		return nil, fmt.Errorf("Configuration passed into backend is nil")
 	}
 	backend.Setup(ctx, conf)
 	b.Backend = backend
@@ -183,10 +186,6 @@ func (b *PassthroughBackend) handleRead() framework.OperationFunc {
 
 		return resp, nil
 	}
-}
-
-func (b *PassthroughBackend) GeneratesLeases() bool {
-	return b.generateLeases
 }
 
 func (b *PassthroughBackend) handleWrite() framework.OperationFunc {

--- a/passthrough_test.go
+++ b/passthrough_test.go
@@ -210,6 +210,25 @@ func TestPassthroughBackend_List(t *testing.T) {
 	test(b)
 }
 
+func TestPassthroughBackend_Renew(t *testing.T) {
+	test := func(b logical.Backend) {
+		req := logical.TestRequest(t, logical.RenewOperation, "kv")
+		req.Secret = &logical.Secret{
+			InternalData: map[string]interface{}{
+				"secret_type": "kv",
+			},
+		}
+
+		if _, err := b.HandleRequest(context.Background(), req); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	}
+	b := testPassthroughBackend()
+	test(b)
+	b = testPassthroughLeasedBackend()
+	test(b)
+}
+
 func TestPassthroughBackend_Revoke(t *testing.T) {
 	test := func(b logical.Backend) {
 		req := logical.TestRequest(t, logical.RevokeOperation, "kv")


### PR DESCRIPTION
Using `handleRead` as the `Renew` method for KV v1 is incorrect and
would fail with the error:

	http: panic serving 127.0.0.1:59579: field path not in the schema

in the Vault server without returning a response.

This fixes by returning an empty response which signals properly that
the secret cannot be renewed.

Also remove `GeneratesLeases()` which was never used and fix a typo in
an error message.
