### PR TITLE
return 404 resp for patch when entry does not exist

### DIFF
--- a/path_data.go
+++ b/path_data.go
@@ -402,10 +402,8 @@ func (b *versionedKVBackend) pathDataPatch() framework.OperationFunc {
 			return nil, err
 		}
 
-		// Returning a nil logical.Response and error will ultimately
-		// result in a 404 HTTP response status
 		if meta == nil {
-			return nil, nil
+			return logical.RespondWithStatusCode(nil, req, http.StatusNotFound)
 		}
 
 		config, err := b.config(ctx, req.Storage)
@@ -427,7 +425,7 @@ func (b *versionedKVBackend) pathDataPatch() framework.OperationFunc {
 		versionMetadata := meta.Versions[currentVersion]
 
 		if versionMetadata == nil {
-			return nil, nil
+			return logical.RespondWithStatusCode(nil, req, http.StatusNotFound)
 		}
 
 		// Like the read handler, initialize a resp with the version metadata

--- a/path_data_test.go
+++ b/path_data_test.go
@@ -615,8 +615,12 @@ func TestVersionedKV_Patch_NotFound(t *testing.T) {
 	}
 
 	resp, err := b.HandleRequest(context.Background(), req)
-	if err != nil || resp != nil {
-		t.Fatalf("expected nil response for PatchOperation - err:%s resp:%#v\n", err, resp)
+	if err != nil || resp == nil || resp.IsError() {
+		t.Fatalf("PatchOperation failed - err:%s resp:%#v", err, resp)
+	}
+
+	if resp.Data["http_status_code"] != 404 {
+		t.Fatalf("expected 404 response for PatchOperation: resp:%#v", resp)
 	}
 
 	metadata := map[string]interface{}{
@@ -634,7 +638,7 @@ func TestVersionedKV_Patch_NotFound(t *testing.T) {
 
 	resp, err = b.HandleRequest(context.Background(), req)
 	if err != nil || resp != nil {
-		t.Fatalf("metadata CreateOperation request failed - err:%s resp:%#v\n", err, resp)
+		t.Fatalf("metadata CreateOperation request failed - err:%s resp:%#v", err, resp)
 	}
 
 	req = &logical.Request{
@@ -645,8 +649,12 @@ func TestVersionedKV_Patch_NotFound(t *testing.T) {
 	}
 
 	resp, err = b.HandleRequest(context.Background(), req)
-	if err != nil || resp != nil {
-		t.Fatalf("expected nil response for PatchOperation - err:%s resp:%#v\n", err, resp)
+	if err != nil || resp == nil || resp.IsError() {
+		t.Fatalf("PatchOperation failed - err:%s resp:%#v", err, resp)
+	}
+
+	if resp.Data["http_status_code"] != 404 {
+		t.Fatalf("expected 404 response for PatchOperation: resp:%#v", resp)
 	}
 }
 


### PR DESCRIPTION
# Overview
Vault PR [#12687](https://github.com/hashicorp/vault/pull/12687) introduced a global translation of a nil `logical.Response` for a `PatchOperation` to a `404 Not Found` response. After further review, this translation cannot be used as there are `CreateOperation` and `UpdateOperation` handlers that return a nil `logical.Response` (ultimately translated to a `204 No Content`. The aforementioned global translation has been removed in Vault PR [#13167](https://github.com/hashicorp/vault/pull/13167).

# Design of Change
 The `PatchOperation` for the KVv2 data endpoint will now return explicit `404 Not Found` responses when an entry does not exist.

# Related Issues/Pull Requests
[#13167](https://github.com/hashicorp/vault/pull/13167)
