### PR TITLE
[VAULT-5501] Remove CreateOperation from KV paths

### DIFF
--- a/delete_version_after_test.go
+++ b/delete_version_after_test.go
@@ -116,7 +116,7 @@ func TestDeleteVersionAfter(t *testing.T) {
 				"delete_version_after": tt.mount.String(),
 			}
 			req := &logical.Request{
-				Operation: logical.CreateOperation,
+				Operation: logical.UpdateOperation,
 				Path:      "config",
 				Storage:   storage,
 				Data:      data,
@@ -210,7 +210,7 @@ func TestDeleteVersionAfter(t *testing.T) {
 				"versions": "1",
 			}
 			req = &logical.Request{
-				Operation: logical.CreateOperation,
+				Operation: logical.UpdateOperation,
 				Path:      "delete/foo",
 				Storage:   storage,
 				Data:      data,
@@ -222,7 +222,7 @@ func TestDeleteVersionAfter(t *testing.T) {
 				"versions": "1",
 			}
 			req = &logical.Request{
-				Operation: logical.CreateOperation,
+				Operation: logical.UpdateOperation,
 				Path:      "undelete/foo",
 				Storage:   storage,
 				Data:      data,

--- a/path_config.go
+++ b/path_config.go
@@ -38,9 +38,6 @@ clears the current setting. Accepts a Go duration format string.`,
 				Callback: b.upgradeCheck(b.pathConfigWrite()),
 				Summary:  "Configure backend level settings that are applied to every key in the key-value store.",
 			},
-			logical.CreateOperation: &framework.PathOperation{
-				Callback: b.upgradeCheck(b.pathConfigWrite()),
-			},
 			logical.ReadOperation: &framework.PathOperation{
 				Callback: b.upgradeCheck(b.pathConfigRead()),
 				Summary:  "Read the backend level settings.",

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -20,7 +20,7 @@ func TestVersionedKV_Config(t *testing.T) {
 	}
 
 	req := &logical.Request{
-		Operation: logical.CreateOperation,
+		Operation: logical.UpdateOperation,
 		Path:      "config",
 		Storage:   storage,
 		Data:      data,
@@ -107,7 +107,7 @@ func TestVersionedKV_Config_DeleteVersionAfter(t *testing.T) {
 				"delete_version_after": tt.ds1,
 			}
 			req = &logical.Request{
-				Operation: logical.CreateOperation,
+				Operation: logical.UpdateOperation,
 				Path:      "config",
 				Storage:   storage,
 				Data:      data,
@@ -135,7 +135,7 @@ func TestVersionedKV_Config_DeleteVersionAfter(t *testing.T) {
 				"delete_version_after": tt.ds2,
 			}
 			req = &logical.Request{
-				Operation: logical.CreateOperation,
+				Operation: logical.UpdateOperation,
 				Path:      "config",
 				Storage:   storage,
 				Data:      data,

--- a/path_data_test.go
+++ b/path_data_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/go-test/deep"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/go-test/deep"
 
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/sdk/helper/logging"
@@ -688,7 +689,7 @@ func TestVersionedKV_Patch_CASValidation(t *testing.T) {
 	}
 
 	req := &logical.Request{
-		Operation: logical.CreateOperation,
+		Operation: logical.UpdateOperation,
 		Path:      "config",
 		Storage:   storage,
 		Data:      config,
@@ -1072,7 +1073,7 @@ func TestVersionedKV_Patch_CurrentVersionDestroyed(t *testing.T) {
 	}
 
 	req = &logical.Request{
-		Operation: logical.CreateOperation,
+		Operation: logical.UpdateOperation,
 		Path:      "destroy/foo",
 		Storage:   storage,
 		Data:      versionsToDestroy,

--- a/path_delete.go
+++ b/path_delete.go
@@ -27,7 +27,6 @@ func pathsDelete(b *versionedKVBackend) []*framework.Path {
 			},
 			Callbacks: map[logical.Operation]framework.OperationFunc{
 				logical.UpdateOperation: b.upgradeCheck(b.pathDeleteWrite()),
-				logical.CreateOperation: b.upgradeCheck(b.pathDeleteWrite()),
 			},
 
 			HelpSynopsis:    deleteHelpSyn,
@@ -47,7 +46,6 @@ func pathsDelete(b *versionedKVBackend) []*framework.Path {
 			},
 			Callbacks: map[logical.Operation]framework.OperationFunc{
 				logical.UpdateOperation: b.upgradeCheck(b.pathUndeleteWrite()),
-				logical.CreateOperation: b.upgradeCheck(b.pathUndeleteWrite()),
 			},
 
 			HelpSynopsis:    undeleteHelpSyn,

--- a/path_delete_test.go
+++ b/path_delete_test.go
@@ -63,7 +63,7 @@ func TestVersionedKV_Delete_Put(t *testing.T) {
 	}
 
 	req = &logical.Request{
-		Operation: logical.CreateOperation,
+		Operation: logical.UpdateOperation,
 		Path:      "delete/foo",
 		Storage:   storage,
 		Data:      data,
@@ -161,7 +161,7 @@ func TestVersionedKV_Undelete_Put(t *testing.T) {
 	}
 
 	req = &logical.Request{
-		Operation: logical.CreateOperation,
+		Operation: logical.UpdateOperation,
 		Path:      "delete/foo",
 		Storage:   storage,
 		Data:      data,
@@ -177,7 +177,7 @@ func TestVersionedKV_Undelete_Put(t *testing.T) {
 	}
 
 	req = &logical.Request{
-		Operation: logical.CreateOperation,
+		Operation: logical.UpdateOperation,
 		Path:      "undelete/foo",
 		Storage:   storage,
 		Data:      data,

--- a/path_destroy.go
+++ b/path_destroy.go
@@ -25,6 +25,7 @@ func pathDestroy(b *versionedKVBackend) *framework.Path {
 		Callbacks: map[logical.Operation]framework.OperationFunc{
 			logical.UpdateOperation: b.upgradeCheck(b.pathDestroyWrite()),
 		},
+
 		HelpSynopsis:    destroyHelpSyn,
 		HelpDescription: destroyHelpDesc,
 	}

--- a/path_destroy.go
+++ b/path_destroy.go
@@ -24,9 +24,7 @@ func pathDestroy(b *versionedKVBackend) *framework.Path {
 		},
 		Callbacks: map[logical.Operation]framework.OperationFunc{
 			logical.UpdateOperation: b.upgradeCheck(b.pathDestroyWrite()),
-			logical.CreateOperation: b.upgradeCheck(b.pathDestroyWrite()),
 		},
-
 		HelpSynopsis:    destroyHelpSyn,
 		HelpDescription: destroyHelpDesc,
 	}

--- a/path_destroy_test.go
+++ b/path_destroy_test.go
@@ -62,7 +62,7 @@ func TestVersionedKV_Destroy_Put(t *testing.T) {
 	}
 
 	req = &logical.Request{
-		Operation: logical.CreateOperation,
+		Operation: logical.UpdateOperation,
 		Path:      "destroy/foo",
 		Storage:   storage,
 		Data:      data,

--- a/path_metadata_test.go
+++ b/path_metadata_test.go
@@ -3,11 +3,12 @@ package kv
 import (
 	"context"
 	"fmt"
-	"github.com/go-test/deep"
-	"github.com/hashicorp/vault/sdk/logical"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/go-test/deep"
+	"github.com/hashicorp/vault/sdk/logical"
 )
 
 func TestVersionedKV_Metadata_Put(t *testing.T) {
@@ -959,7 +960,7 @@ func TestVersionedKV_Metadata_Patch_CasRequiredWarning(t *testing.T) {
 	b, storage := getBackend(t)
 
 	req := &logical.Request{
-		Operation: logical.CreateOperation,
+		Operation: logical.UpdateOperation,
 		Path:      "config",
 		Storage:   storage,
 		Data: map[string]interface{}{

--- a/path_subkeys_test.go
+++ b/path_subkeys_test.go
@@ -506,7 +506,7 @@ func TestVersionedKV_Subkeys_VersionDestroyed(t *testing.T) {
 	}
 
 	req = &logical.Request{
-		Operation: logical.CreateOperation,
+		Operation: logical.UpdateOperation,
 		Path:      "destroy/foo",
 		Storage:   storage,
 		Data: map[string]interface{}{


### PR DESCRIPTION
# Overview
A high level description of the contribution, including:
Who the change affects or is for (stakeholders)?
This affects those using OpenApi Spec generation to vet Vault policies

What is the change? 
Removing `CreateOperation` from Callbacks/Operations list that don't implement the `ExistenceCheck`

Why is the change needed?
This affects those using OpenApi Spec generation b/c the `x-vault-createSupported` is advertised for those paths that have the `CreateOperation` in their Callbacks/Operations maps, but this is meaningless for paths that don't also implement the `ExistenceCheck`

How does this change affect the user experience (if at all)?
A cleaner and more accurate OpenApi Spec

# Design of Change
How was this change implemented?
Removed the `CreateOperation` from paths that didn't also implement the `ExistenceCheck`. Verified each path still worked properly and the OpenApi Spec generation no longer included the `x-vault-createSupported

# Related Issues/Pull Requests
[X] [Issue #12329](https://github.com/hashicorp/vault/issues/12329)
[X] [PR #14919](https://github.com/hashicorp/vault/pull/14919)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible
