### PR TITLE
Remove trailing spaces from a path if it is a `CreateOperation`

### DIFF
--- a/path_data.go
+++ b/path_data.go
@@ -356,7 +356,7 @@ func (b *versionedKVBackend) pathDataWrite() framework.OperationFunc {
 		}
 
 		if isTrimmed {
-			resp.AddWarning("Path contains a trailing whitespace that has been trimmed")
+			resp.AddWarning("Path contains a leading or trailing whitespace that has been trimmed")
 		}
 
 		warning := b.cleanupOldVersions(ctx, req.Storage, key, versionToDelete)

--- a/path_data.go
+++ b/path_data.go
@@ -252,8 +252,10 @@ func (b *versionedKVBackend) pathDataWrite() framework.OperationFunc {
 			return logical.ErrorResponse("missing path"), nil
 		}
 
-		if req.Operation == logical.CreateOperation {
+		isTrimmed := false
+		if req.Operation == logical.CreateOperation && strings.HasSuffix(key, " ") {
 			key = strings.TrimSpace(key)
+			isTrimmed = true
 		}
 
 		config, err := b.config(ctx, req.Storage)
@@ -351,6 +353,10 @@ func (b *versionedKVBackend) pathDataWrite() framework.OperationFunc {
 				"destroyed":       vm.Destroyed,
 				"custom_metadata": meta.CustomMetadata,
 			},
+		}
+
+		if isTrimmed {
+			resp.AddWarning("Path contains a trailing whitespace that has been trimmed")
 		}
 
 		warning := b.cleanupOldVersions(ctx, req.Storage, key, versionToDelete)

--- a/path_data.go
+++ b/path_data.go
@@ -252,6 +252,10 @@ func (b *versionedKVBackend) pathDataWrite() framework.OperationFunc {
 			return logical.ErrorResponse("missing path"), nil
 		}
 
+		if req.Operation == logical.CreateOperation {
+			key = strings.TrimSpace(key)
+		}
+
 		config, err := b.config(ctx, req.Storage)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
# Overview
A high level description of the contribution, including:
This change is related to a github issue, where we're attempting to make the API and cli consistent when handling trailing white spaces. In this case, we want to prevent users from creating new secrets with trailing spaces, while letting them update existing ones. 

# Design of Change
How was this change implemented?
Check if we're receiving a `CreateOperation` and 

# Related Issues/Pull Requests
[x] [Issue #14990](https://github.com/hashicorp/vault/issues/14990)
[x] [PR #15188](https://github.com/hashicorp/vault/pr/15188)
