### PR TITLE
pass map representation of proto duration for patch of delete_version_after

### DIFF
--- a/path_metadata_test.go
+++ b/path_metadata_test.go
@@ -1189,10 +1189,10 @@ func TestVersionedKV_Metadata_Patch_Success(t *testing.T) {
 			map[string]interface{}{
 				"cas_required":         true,
 				"max_versions":         uint32(15),
-				"delete_version_after": nil,
+				"delete_version_after": "0s",
 				"updated_time":         ignoreVal,
 			},
-			2,
+			3,
 		},
 	}
 
@@ -1207,6 +1207,7 @@ func TestVersionedKV_Metadata_Patch_Success(t *testing.T) {
 				Storage:   storage,
 				Data: map[string]interface{}{
 					"max_versions": uint32(10),
+					"delete_version_after": "10s",
 				},
 			}
 


### PR DESCRIPTION
# Overview
Attempting to PATCH KVv2 metadata `delete_version_after` field with a value of `0s` for an entry whose value is non-zero does not work. This ultimately is due to the fact that `durationpb.Duration` struct contains `omitempty` json tags (the `json-patch` library requires marshaled JSON byte arrays) for its underlying fields. With that provided `0s` will marshal into `{}` rather than `{"seconds": 0, "nanos": 0}`. An empty map is treated as a NOOP when it comes to JSON merge patches.

# Design of Change
A fix has been added to the patch preprocessor for the KVv2 metadata endpoint. Rather than provided the incoming `delete_version_after` field as a `durationpb.Duration`, that duration is converted into a map inline to match the resulting structure of marshaling as JSON minus the omission of empty values.

Attempting to treat both the `delete_version_after` value of both the input data and existing resource as integers (as provided by `framework.TypeDurationSecond`) resulted in more complex logic as it required both pre and post processing of the existing resource data. Due to the added complexity, the fix provided in this PR seemed more ideal.

A changelog entry will be added to Vault once a new version is of this plugin is cut and thus upgraded in that repo.
