### PR TITLE
Prevent the pattern matching for KV V2 operations if a trailing slash…

### DIFF
--- a/path_data.go
+++ b/path_data.go
@@ -18,11 +18,15 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+func matchAllNoTrailingSlashRegex(name string) string {
+	return fmt.Sprintf(`(?P<%s>.*?[^/])`, name)
+}
+
 // pathConfig returns the path configuration for CRUD operations on the backend
 // configuration.
 func pathData(b *versionedKVBackend) *framework.Path {
 	return &framework.Path{
-		Pattern: "data/" + framework.MatchAllRegex("path"),
+		Pattern: "data/" + matchAllNoTrailingSlashRegex("path"),
 		Fields: map[string]*framework.FieldSchema{
 			"path": {
 				Type:        framework.TypeString,

--- a/path_data.go
+++ b/path_data.go
@@ -19,7 +19,7 @@ import (
 )
 
 func matchAllNoTrailingSlashRegex(name string) string {
-	return fmt.Sprintf(`(?P<%s>.*?[^/])`, name)
+	return fmt.Sprintf(`(?P<%s>.*?[^/]$)`, name)
 }
 
 // pathConfig returns the path configuration for CRUD operations on the backend

--- a/path_data_test.go
+++ b/path_data_test.go
@@ -1168,10 +1168,14 @@ func TestRegex_AllNoTrailingSlash(t *testing.T) {
 		input string
 		want  bool
 	}{
-		"single-part-no-trailing-slash": {input: "data/foo", want: true},
-		"single-part-trailing-slash":    {input: "data/foo/", want: false},
-		"multi-part-no-trailing-slash":  {input: "data/foo/bar", want: true},
-		"multi-part-trailing-slash":     {input: "data/foo/bar/", want: false},
+		"single-part-no-trailing-slash":         {input: "data/foo", want: true},
+		"single-part-trailing-slash":            {input: "data/foo/", want: false},
+		"multi-part-no-trailing-slash":          {input: "data/foo/bar", want: true},
+		"multi-part-trailing-slash":             {input: "data/foo/bar/", want: false},
+		"no-data-single-part-no-trailing-slash": {input: "foo", want: false},
+		"no-data-single-part-trailing-slash":    {input: "foo/", want: false},
+		"no-data-multi-part-no-trailing-slash":  {input: "foo/bar", want: false},
+		"no-data-multi-part-trailing-slash":     {input: "foo/bar/", want: false},
 	}
 
 	p := "data/" + matchAllNoTrailingSlashRegex("path")

--- a/path_data_test.go
+++ b/path_data_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/go-test/deep"
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/go-test/deep"
 
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/sdk/helper/logging"
@@ -1158,5 +1160,27 @@ func TestVersionedKV_Patch_CurrentVersionDestroyed(t *testing.T) {
 		respData["version"] != float64(1) ||
 		(respData["destroyed"] == nil || !respData["destroyed"].(bool)) {
 		t.Fatalf("Expected 404 status code for destroyed version: resp:%#v\n", resp)
+	}
+}
+
+func TestRegex_AllNoTrailingSlash(t *testing.T) {
+	tests := map[string]struct {
+		input string
+		want  bool
+	}{
+		"single-part-no-trailing-slash": {input: "data/foo", want: true},
+		"single-part-trailing-slash":    {input: "data/foo/", want: false},
+		"multi-part-no-trailing-slash":  {input: "data/foo/bar", want: true},
+		"multi-part-trailing-slash":     {input: "data/foo/bar/", want: false},
+	}
+
+	p := "data/" + matchAllNoTrailingSlashRegex("path")
+	r, _ := regexp.Compile(p)
+
+	for name, tc := range tests {
+		got := r.MatchString(tc.input)
+		if tc.want != got {
+			t.Errorf("%s: expected: %v, got: %v", name, tc.want, got)
+		}
 	}
 }


### PR DESCRIPTION
… is present in the URL

# Overview

Kv v1 secrets engine returns a 404 if you attempt to perform actions on an endpoint with a trailing slash (i.e. an endpoint that doesn't exist). 

KV v2 however allows this, but due to the way it handles metadata via the storage backends this can lead to a situation where a `500 Internal Server Error` is returned as the secret cannot be found, but metadata can.

This change prevents the code from running by adjusting the pattern matcher in the framework. 

Solves: VAULT-6804
