### PR TITLE
VAULT-8631 Make upgrade synchronous when no keys to upgrade

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -90,7 +90,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 	return b, nil
 }
 
-// Factory returns a new backend as logical.Backend.
+// VersionedKVFactory returns a new KVV2 backend as logical.Backend.
 func VersionedKVFactory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
 	upgradeCtx, upgradeCancelFunc := context.WithCancel(ctx)
 

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -157,5 +157,4 @@ func TestVersionedKV_Config_DeleteVersionAfter(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/path_data_test.go
+++ b/path_data_test.go
@@ -28,36 +28,23 @@ func getBackend(t *testing.T) (logical.Backend, logical.Storage) {
 		t.Fatalf("unable to create backend: %v", err)
 	}
 
-	// Wait for the upgrade to finish
-	timeout := time.After(20 * time.Second)
-	ticker := time.Tick(time.Second)
-
-	for {
-		select {
-		case <-timeout:
-			t.Fatal("timeout expired waiting for upgrade")
-		case <-ticker:
-			req := &logical.Request{
-				Operation: logical.ReadOperation,
-				Path:      "config",
-				Storage:   config.StorageView,
-			}
-
-			resp, err := b.HandleRequest(context.Background(), req)
-			if err != nil {
-				t.Fatalf("unable to read config: %s", err.Error())
-				return nil, nil
-			}
-
-			if resp != nil && !resp.IsError() {
-				return b, config.StorageView
-			}
-
-			if resp == nil || (resp.IsError() && strings.Contains(resp.Error().Error(), "Upgrading from non-versioned to versioned")) {
-				t.Log("waiting for upgrade to complete")
-			}
-		}
+	req := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "config",
+		Storage:   config.StorageView,
 	}
+
+	resp, err := b.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unable to read config: %s", err.Error())
+		return nil, nil
+	}
+
+	if resp == nil || resp.IsError() {
+		t.Fatalf("Error during mount creation: %x", resp.Error().Error())
+	}
+
+	return b, config.StorageView
 }
 
 // getKeySet will produce a set of the keys that exist in m


### PR DESCRIPTION
This makes the upgrade synchronous when there are no keys in the KV mount (such as when we are creating a new KVV2 mount).

This should make things easier as the mount will be available to use as soon as the mount creation request succeeds, making things easier for users.

All tests pass (and are much faster!) and all tests should implicitly test this feature. Introducing some latency into the upgrade process make the tests fail consistently without my change and pass consistently with it.

