### PR TITLE
VAULT-8631 Make upgrade synchronous when no keys to upgrade (#66)

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -90,7 +90,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 	return b, nil
 }
 
-// Factory returns a new backend as logical.Backend.
+// VersionedKVFactory returns a new KVV2 backend as logical.Backend.
 func VersionedKVFactory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
 	upgradeCtx, upgradeCancelFunc := context.WithCancel(ctx)
 

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -157,5 +157,4 @@ func TestVersionedKV_Config_DeleteVersionAfter(t *testing.T) {
 			}
 		})
 	}
-
 }


### PR DESCRIPTION
Port change to release branch for Vault 1.13.

I'm trying to follow https://hashicorp.atlassian.net/wiki/spaces/VAULT/pages/1325563980/Plugin+Release+Process to get my change in the right branch. The branch already exists, so I think I'm meant to port the change to it.