### PR TITLE
VAULT-8631 - Change synchronous logic to 

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -90,7 +90,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 	return b, nil
 }
 
-// Factory returns a new backend as logical.Backend.
+// VersionedKVFactory returns a new KVV2 backend as logical.Backend.
 func VersionedKVFactory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
 	upgradeCtx, upgradeCancelFunc := context.WithCancel(ctx)
 

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -157,5 +157,4 @@ func TestVersionedKV_Config_DeleteVersionAfter(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/path_data_test.go
+++ b/path_data_test.go
@@ -28,36 +28,23 @@ func getBackend(t *testing.T) (logical.Backend, logical.Storage) {
 		t.Fatalf("unable to create backend: %v", err)
 	}
 
-	// Wait for the upgrade to finish
-	timeout := time.After(20 * time.Second)
-	ticker := time.Tick(time.Second)
-
-	for {
-		select {
-		case <-timeout:
-			t.Fatal("timeout expired waiting for upgrade")
-		case <-ticker:
-			req := &logical.Request{
-				Operation: logical.ReadOperation,
-				Path:      "config",
-				Storage:   config.StorageView,
-			}
-
-			resp, err := b.HandleRequest(context.Background(), req)
-			if err != nil {
-				t.Fatalf("unable to read config: %s", err.Error())
-				return nil, nil
-			}
-
-			if resp != nil && !resp.IsError() {
-				return b, config.StorageView
-			}
-
-			if resp == nil || (resp.IsError() && strings.Contains(resp.Error().Error(), "Upgrading from non-versioned to versioned")) {
-				t.Log("waiting for upgrade to complete")
-			}
-		}
+	req := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "config",
+		Storage:   config.StorageView,
 	}
+
+	resp, err := b.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unable to read config: %s", err.Error())
+		return nil, nil
+	}
+
+	if resp == nil || resp.IsError() {
+		t.Fatalf("Error during mount creation: %x", resp.Error().Error())
+	}
+
+	return b, config.StorageView
 }
 
 // getKeySet will produce a set of the keys that exist in m

--- a/path_metadata.go
+++ b/path_metadata.go
@@ -342,7 +342,7 @@ func metadataPatchPreprocessor() framework.PatchPreprocessorFunc {
 					// map-representation of the data to enable patching with "0s"
 					patchData[k] = map[string]interface{}{
 						"seconds": d.Seconds,
-						"nanos": d.Nanos,
+						"nanos":   d.Nanos,
 					}
 				} else {
 					patchData[k] = v

--- a/path_metadata_test.go
+++ b/path_metadata_test.go
@@ -1206,7 +1206,7 @@ func TestVersionedKV_Metadata_Patch_Success(t *testing.T) {
 				Path:      path,
 				Storage:   storage,
 				Data: map[string]interface{}{
-					"max_versions": uint32(10),
+					"max_versions":         uint32(10),
 					"delete_version_after": "10s",
 				},
 			}


### PR DESCRIPTION
This is an addition to https://github.com/hashicorp/vault-plugin-secrets-kv/commit/cc06d01757ed8d20a9961be77bb46104c1be0805 as that pull request was not compatible with Vault making mounts read-only during mounting.

The approach has been modified:
- We set to having upgraded immediately (which is what's used to determine if the mount is 'ready')
- We delay the insertion of the 'upgraded' entry in the mount until after it has been fully mounted