### PR TITLE
(Port to release branch) VAULT-8631 - Change synchronous logic to insert storage entry after mounting (#69)

### DIFF
--- a/path_metadata.go
+++ b/path_metadata.go
@@ -342,7 +342,7 @@ func metadataPatchPreprocessor() framework.PatchPreprocessorFunc {
 					// map-representation of the data to enable patching with "0s"
 					patchData[k] = map[string]interface{}{
 						"seconds": d.Seconds,
-						"nanos": d.Nanos,
+						"nanos":   d.Nanos,
 					}
 				} else {
 					patchData[k] = v

--- a/path_metadata_test.go
+++ b/path_metadata_test.go
@@ -1206,7 +1206,7 @@ func TestVersionedKV_Metadata_Patch_Success(t *testing.T) {
 				Path:      path,
 				Storage:   storage,
 				Data: map[string]interface{}{
-					"max_versions": uint32(10),
+					"max_versions":         uint32(10),
 					"delete_version_after": "10s",
 				},
 			}

--- a/upgrade.go
+++ b/upgrade.go
@@ -201,6 +201,34 @@ func (b *versionedKVBackend) Upgrade(ctx context.Context, s logical.Storage) err
 		return nil
 	}
 
+	prepareUpgradeInfoDoneFunc := func() ([]byte, error) {
+		upgradeInfo.Done = true
+		info, err := proto.Marshal(upgradeInfo)
+		if err != nil {
+			b.Logger().Error("encoding upgrade info resulted in an error", "error", err)
+			return nil, err
+		}
+		return info, nil
+	}
+
+	writeUpgradeInfoDoneFunc := func(info []byte) {
+		for {
+			err = s.Put(ctx, &logical.StorageEntry{
+				Key:   path.Join(b.storagePrefix, "upgrading"),
+				Value: info,
+			})
+			switch {
+			case err == nil:
+				return
+			case err.Error() == logical.ErrSetupReadOnly.Error():
+				time.Sleep(10 * time.Millisecond)
+			default:
+				b.Logger().Error("writing upgrade info resulted in an error, but all keys were successfully upgraded", "error", err)
+				return
+			}
+		}
+	}
+
 	upgradeFunc := func() {
 		// Write the canary value and if we are read only wait until the setup
 		// process has finished.
@@ -250,26 +278,25 @@ func (b *versionedKVBackend) Upgrade(ctx context.Context, s logical.Storage) err
 		}
 		b.l.Unlock()
 
-		// Write upgrade done value
-		upgradeInfo.Done = true
-		info, err := proto.Marshal(upgradeInfo)
+		info, err := prepareUpgradeInfoDoneFunc()
 		if err != nil {
-			b.Logger().Error("encoding upgrade info resulted in an error", "error", err)
+			b.Logger().Error("error marshalling upgrade info after upgrade", "error", err)
+			return
 		}
-
-		err = s.Put(ctx, &logical.StorageEntry{
-			Key:   path.Join(b.storagePrefix, "upgrading"),
-			Value: info,
-		})
-		if err != nil {
-			b.Logger().Error("writing upgrade done resulted in an error", "error", err)
-		}
-
+		writeUpgradeInfoDoneFunc(info)
 		atomic.StoreUint32(b.upgrading, 0)
 	}
 
 	if upgradeSynchronously {
-		upgradeFunc()
+		// Set us to having 'upgraded' before we insert the upgrade value, as the mount is ready to use now
+		atomic.StoreUint32(b.upgrading, 0)
+		info, err := prepareUpgradeInfoDoneFunc()
+		if err != nil {
+			return err
+		}
+		// We write the upgrade done info into storage in a goroutine, as a Vault mount is set to read only
+		// during the mount process, so we cannot do it now
+		go writeUpgradeInfoDoneFunc(info)
 	} else {
 		// We run the actual upgrade in a go routine, so we don't block the client on a
 		// potentially long process.


### PR DESCRIPTION
Cherry picked commit from  https://github.com/hashicorp/vault-plugin-secrets-kv/pull/69 and made a PR.

See also: https://github.com/hashicorp/vault-plugin-secrets-kv/pull/67