### PR TITLE
Convert from Callbacks to Operations

### DIFF
--- a/passthrough.go
+++ b/passthrough.go
@@ -51,7 +51,7 @@ func LeaseSwitchedPassthroughBackend(ctx context.Context, conf *logical.BackendC
 		},
 
 		Paths: []*framework.Path{
-			&framework.Path{
+			{
 				Pattern: framework.MatchAllRegex("path"),
 
 				Fields: map[string]*framework.FieldSchema{
@@ -61,12 +61,22 @@ func LeaseSwitchedPassthroughBackend(ctx context.Context, conf *logical.BackendC
 					},
 				},
 
-				Callbacks: map[logical.Operation]framework.OperationFunc{
-					logical.ReadOperation:   b.handleRead(),
-					logical.CreateOperation: b.handleWrite(),
-					logical.UpdateOperation: b.handleWrite(),
-					logical.DeleteOperation: b.handleDelete(),
-					logical.ListOperation:   b.handleList(),
+				Operations: map[logical.Operation]framework.OperationHandler{
+					logical.ReadOperation: &framework.PathOperation{
+						Callback: b.handleRead(),
+					},
+					logical.CreateOperation: &framework.PathOperation{
+						Callback: b.handleWrite(),
+					},
+					logical.UpdateOperation: &framework.PathOperation{
+						Callback: b.handleWrite(),
+					},
+					logical.DeleteOperation: &framework.PathOperation{
+						Callback: b.handleDelete(),
+					},
+					logical.ListOperation: &framework.PathOperation{
+						Callback: b.handleList(),
+					},
 				},
 
 				ExistenceCheck: b.handleExistenceCheck(),
@@ -76,7 +86,7 @@ func LeaseSwitchedPassthroughBackend(ctx context.Context, conf *logical.BackendC
 			},
 		},
 		Secrets: []*framework.Secret{
-			&framework.Secret{
+			{
 				Type: "kv",
 
 				Renew: b.handleRead(),

--- a/path_data.go
+++ b/path_data.go
@@ -50,12 +50,22 @@ version matches the version specified in the cas parameter.`,
 				Description: "The contents of the data map will be stored and returned on read.",
 			},
 		},
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation: b.upgradeCheck(b.pathDataWrite()),
-			logical.CreateOperation: b.upgradeCheck(b.pathDataWrite()),
-			logical.ReadOperation:   b.upgradeCheck(b.pathDataRead()),
-			logical.DeleteOperation: b.upgradeCheck(b.pathDataDelete()),
-			logical.PatchOperation:  b.upgradeCheck(b.pathDataPatch()),
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.upgradeCheck(b.pathDataWrite()),
+			},
+			logical.CreateOperation: &framework.PathOperation{
+				Callback: b.upgradeCheck(b.pathDataWrite()),
+			},
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.upgradeCheck(b.pathDataRead()),
+			},
+			logical.DeleteOperation: &framework.PathOperation{
+				Callback: b.upgradeCheck(b.pathDataDelete()),
+			},
+			logical.PatchOperation: &framework.PathOperation{
+				Callback: b.upgradeCheck(b.pathDataPatch()),
+			},
 		},
 
 		ExistenceCheck: b.dataExistenceCheck(),

--- a/path_delete.go
+++ b/path_delete.go
@@ -13,7 +13,7 @@ import (
 // pathsDelete returns the path configuration for the delete and undelete paths
 func pathsDelete(b *versionedKVBackend) []*framework.Path {
 	return []*framework.Path{
-		&framework.Path{
+		{
 			Pattern: "delete/" + framework.MatchAllRegex("path"),
 			Fields: map[string]*framework.FieldSchema{
 				"path": {
@@ -25,15 +25,19 @@ func pathsDelete(b *versionedKVBackend) []*framework.Path {
 					Description: "The versions to be archived. The versioned data will not be deleted, but it will no longer be returned in normal get requests.",
 				},
 			},
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.UpdateOperation: b.upgradeCheck(b.pathDeleteWrite()),
-				logical.CreateOperation: b.upgradeCheck(b.pathDeleteWrite()),
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback: b.upgradeCheck(b.pathDeleteWrite()),
+				},
+				logical.CreateOperation: &framework.PathOperation{
+					Callback: b.upgradeCheck(b.pathDeleteWrite()),
+				},
 			},
 
 			HelpSynopsis:    deleteHelpSyn,
 			HelpDescription: deleteHelpDesc,
 		},
-		&framework.Path{
+		{
 			Pattern: "undelete/" + framework.MatchAllRegex("path"),
 			Fields: map[string]*framework.FieldSchema{
 				"path": {
@@ -45,9 +49,13 @@ func pathsDelete(b *versionedKVBackend) []*framework.Path {
 					Description: "The versions to unarchive. The versions will be restored and their data will be returned on normal get requests.",
 				},
 			},
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.UpdateOperation: b.upgradeCheck(b.pathUndeleteWrite()),
-				logical.CreateOperation: b.upgradeCheck(b.pathUndeleteWrite()),
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback: b.upgradeCheck(b.pathUndeleteWrite()),
+				},
+				logical.CreateOperation: &framework.PathOperation{
+					Callback: b.upgradeCheck(b.pathUndeleteWrite()),
+				},
 			},
 
 			HelpSynopsis:    undeleteHelpSyn,

--- a/path_destroy.go
+++ b/path_destroy.go
@@ -22,9 +22,13 @@ func pathDestroy(b *versionedKVBackend) *framework.Path {
 				Description: "The versions to destroy. Their data will be permanently deleted.",
 			},
 		},
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation: b.upgradeCheck(b.pathDestroyWrite()),
-			logical.CreateOperation: b.upgradeCheck(b.pathDestroyWrite()),
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.upgradeCheck(b.pathDestroyWrite()),
+			},
+			logical.CreateOperation: &framework.PathOperation{
+				Callback: b.upgradeCheck(b.pathDestroyWrite()),
+			},
 		},
 
 		HelpSynopsis:    destroyHelpSyn,

--- a/path_metadata.go
+++ b/path_metadata.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-secure-stdlib/strutil"
-	"github.com/mitchellh/mapstructure"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-secure-stdlib/strutil"
+	"github.com/mitchellh/mapstructure"
 
 	"github.com/golang/protobuf/ptypes"
 	"github.com/hashicorp/vault/sdk/framework"
@@ -56,13 +57,25 @@ version-agnostic information about a secret.
 `,
 			},
 		},
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation: b.upgradeCheck(b.pathMetadataWrite()),
-			logical.CreateOperation: b.upgradeCheck(b.pathMetadataWrite()),
-			logical.ReadOperation:   b.upgradeCheck(b.pathMetadataRead()),
-			logical.DeleteOperation: b.upgradeCheck(b.pathMetadataDelete()),
-			logical.ListOperation:   b.upgradeCheck(b.pathMetadataList()),
-			logical.PatchOperation:  b.upgradeCheck(b.pathMetadataPatch()),
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.upgradeCheck(b.pathMetadataWrite()),
+			},
+			logical.CreateOperation: &framework.PathOperation{
+				Callback: b.upgradeCheck(b.pathMetadataWrite()),
+			},
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.upgradeCheck(b.pathMetadataRead()),
+			},
+			logical.DeleteOperation: &framework.PathOperation{
+				Callback: b.upgradeCheck(b.pathMetadataDelete()),
+			},
+			logical.ListOperation: &framework.PathOperation{
+				Callback: b.upgradeCheck(b.pathMetadataList()),
+			},
+			logical.PatchOperation: &framework.PathOperation{
+				Callback: b.upgradeCheck(b.pathMetadataPatch()),
+			},
 		},
 
 		ExistenceCheck: b.metadataExistenceCheck(),

--- a/path_metadata.go
+++ b/path_metadata.go
@@ -8,14 +8,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/golang/protobuf/ptypes"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
-	"github.com/mitchellh/mapstructure"
-
-	"github.com/golang/protobuf/ptypes"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/locksutil"
 	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/mitchellh/mapstructure"
 )
 
 // pathMetadata returns the path configuration for CRUD operations on the

--- a/path_subkeys.go
+++ b/path_subkeys.go
@@ -32,8 +32,10 @@ func pathSubkeys(b *versionedKVBackend) *framework.Path {
 				Description: "Specifies which version to retrieve. If not provided, the current version will be used.",
 			},
 		},
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.ReadOperation: b.upgradeCheck(b.pathSubkeysRead()),
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.upgradeCheck(b.pathSubkeysRead()),
+			},
 		},
 
 		HelpSynopsis:    subkeysHelpSyn,


### PR DESCRIPTION
# Overview

Several Path definitions within this plugin use a deprecated `Callbacks` property. This PR replaces the `Callbacks` with the corresponding `Operations`. There should be no functional changes to any of the users of this plugin.

This change is needed to add structured response support (implemented in another PR)

# Related Issues/Pull Requests

- [VAULT-12113](https://hashicorp.atlassian.net/browse/VAULT-12113)