### PR TITLE
Improve response schema validation tests

### DIFF
--- a/passthrough_test.go
+++ b/passthrough_test.go
@@ -53,7 +53,7 @@ func TestPassthroughBackend_Write(t *testing.T) {
 		}
 		schema.ValidateResponse(
 			t,
-			schema.FindResponseSchema(t, b.(*PassthroughBackend).Paths, 0, logical.UpdateOperation),
+			schema.FindResponseSchema(t, b.(*PassthroughBackend).Paths, 0, req.Operation),
 			resp,
 			true,
 		)
@@ -101,7 +101,7 @@ func TestPassthroughBackend_Read(t *testing.T) {
 		}
 		schema.ValidateResponse(
 			t,
-			schema.FindResponseSchema(t, b.(*PassthroughBackend).Paths, 0, logical.ReadOperation),
+			schema.FindResponseSchema(t, b.(*PassthroughBackend).Paths, 0, req.Operation),
 			resp,
 			true,
 		)
@@ -175,7 +175,7 @@ func TestPassthroughBackend_Delete(t *testing.T) {
 		}
 		schema.ValidateResponse(
 			t,
-			schema.FindResponseSchema(t, b.(*PassthroughBackend).Paths, 0, logical.DeleteOperation),
+			schema.FindResponseSchema(t, b.(*PassthroughBackend).Paths, 0, req.Operation),
 			resp,
 			true,
 		)
@@ -191,7 +191,7 @@ func TestPassthroughBackend_Delete(t *testing.T) {
 		}
 		schema.ValidateResponse(
 			t,
-			schema.FindResponseSchema(t, b.(*PassthroughBackend).Paths, 0, logical.ReadOperation),
+			schema.FindResponseSchema(t, b.(*PassthroughBackend).Paths, 0, req.Operation),
 			resp,
 			true,
 		)
@@ -220,7 +220,7 @@ func TestPassthroughBackend_List(t *testing.T) {
 		}
 		schema.ValidateResponse(
 			t,
-			schema.FindResponseSchema(t, b.(*PassthroughBackend).Paths, 0, logical.ListOperation),
+			schema.FindResponseSchema(t, b.(*PassthroughBackend).Paths, 0, req.Operation),
 			resp,
 			true,
 		)

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -36,7 +36,7 @@ func TestVersionedKV_Config(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -53,7 +53,7 @@ func TestVersionedKV_Config(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.ReadOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -116,7 +116,7 @@ func TestVersionedKV_Config_DeleteVersionAfter(t *testing.T) {
 			wantResponse(t, resp, err)
 			schema.ValidateResponse(
 				t,
-				schema.FindResponseSchema(t, paths, 0, logical.ReadOperation),
+				schema.FindResponseSchema(t, paths, 0, req.Operation),
 				resp,
 				true,
 			)
@@ -141,7 +141,7 @@ func TestVersionedKV_Config_DeleteVersionAfter(t *testing.T) {
 			wantNoResponse(t, resp, err)
 			schema.ValidateResponse(
 				t,
-				schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+				schema.FindResponseSchema(t, paths, 0, req.Operation),
 				resp,
 				true,
 			)
@@ -155,7 +155,7 @@ func TestVersionedKV_Config_DeleteVersionAfter(t *testing.T) {
 			wantResponse(t, resp, err)
 			schema.ValidateResponse(
 				t,
-				schema.FindResponseSchema(t, paths, 0, logical.ReadOperation),
+				schema.FindResponseSchema(t, paths, 0, req.Operation),
 				resp,
 				true,
 			)
@@ -181,7 +181,7 @@ func TestVersionedKV_Config_DeleteVersionAfter(t *testing.T) {
 			wantNoResponse(t, resp, err)
 			schema.ValidateResponse(
 				t,
-				schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+				schema.FindResponseSchema(t, paths, 0, req.Operation),
 				resp,
 				true,
 			)
@@ -195,7 +195,7 @@ func TestVersionedKV_Config_DeleteVersionAfter(t *testing.T) {
 			wantResponse(t, resp, err)
 			schema.ValidateResponse(
 				t,
-				schema.FindResponseSchema(t, paths, 0, logical.ReadOperation),
+				schema.FindResponseSchema(t, paths, 0, req.Operation),
 				resp,
 				true,
 			)

--- a/path_data_test.go
+++ b/path_data_test.go
@@ -119,7 +119,7 @@ func TestVersionedKV_Data_Put(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -158,7 +158,7 @@ func TestVersionedKV_Data_Put(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -203,7 +203,7 @@ func TestVersionedKV_Data_Put_ZeroCas(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -287,7 +287,7 @@ func TestVersionedKV_Data_Get(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -308,7 +308,7 @@ func TestVersionedKV_Data_Get(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.ReadOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -369,7 +369,7 @@ func TestVersionedKV_Data_Delete(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -390,7 +390,7 @@ func TestVersionedKV_Data_Delete(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.DeleteOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -453,7 +453,7 @@ func TestVersionedKV_Data_Put_CleanupOldVersions(t *testing.T) {
 		}
 		schema.ValidateResponse(
 			t,
-			schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+			schema.FindResponseSchema(t, paths, 0, req.Operation),
 			resp,
 			true,
 		)
@@ -501,7 +501,7 @@ func TestVersionedKV_Data_Put_CleanupOldVersions(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -555,7 +555,7 @@ func TestVersionedKV_Data_Patch_CleanupOldVersions(t *testing.T) {
 		}
 		schema.ValidateResponse(
 			t,
-			schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+			schema.FindResponseSchema(t, paths, 0, req.Operation),
 			resp,
 			true,
 		)
@@ -603,7 +603,7 @@ func TestVersionedKV_Data_Patch_CleanupOldVersions(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.PatchOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -658,7 +658,7 @@ func TestVersionedKV_Reload_Policy(t *testing.T) {
 		}
 		schema.ValidateResponse(
 			t,
-			schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+			schema.FindResponseSchema(t, paths, 0, req.Operation),
 			resp,
 			true,
 		)
@@ -690,7 +690,7 @@ func TestVersionedKV_Reload_Policy(t *testing.T) {
 		}
 		schema.ValidateResponse(
 			t,
-			schema.FindResponseSchema(t, paths, 0, logical.ReadOperation),
+			schema.FindResponseSchema(t, paths, 0, req.Operation),
 			resp,
 			true,
 		)
@@ -806,7 +806,7 @@ func TestVersionedKV_Patch_CASValidation(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -894,7 +894,7 @@ func TestVersionedKV_Patch_NoData(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -971,7 +971,7 @@ func TestVersionedKV_Patch_Success(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -1011,7 +1011,7 @@ func TestVersionedKV_Patch_Success(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.PatchOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -1037,7 +1037,7 @@ func TestVersionedKV_Patch_Success(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.ReadOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -1080,7 +1080,7 @@ func TestVersionedKV_Patch_CurrentVersionDeleted(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -1098,7 +1098,7 @@ func TestVersionedKV_Patch_CurrentVersionDeleted(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.DeleteOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -1203,7 +1203,7 @@ func TestVersionedKV_Patch_CurrentVersionDestroyed(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)

--- a/path_delete_test.go
+++ b/path_delete_test.go
@@ -78,7 +78,7 @@ func TestVersionedKV_Delete_Put(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -184,7 +184,7 @@ func TestVersionedKV_Undelete_Put(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -206,7 +206,7 @@ func TestVersionedKV_Undelete_Put(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 1, logical.CreateOperation),
+		schema.FindResponseSchema(t, paths, 1, req.Operation),
 		resp,
 		true,
 	)

--- a/path_destroy_test.go
+++ b/path_destroy_test.go
@@ -78,7 +78,7 @@ func TestVersionedKV_Destroy_Put(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)

--- a/path_metadata_test.go
+++ b/path_metadata_test.go
@@ -45,7 +45,7 @@ func TestVersionedKV_Metadata_Put(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -62,7 +62,7 @@ func TestVersionedKV_Metadata_Put(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.ReadOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -189,7 +189,7 @@ func TestVersionedKV_Metadata_Put(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.ReadOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -230,7 +230,7 @@ func TestVersionedKV_Metadata_Put(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -270,7 +270,7 @@ func TestVersionedKV_Metadata_Put(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.ReadOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -334,7 +334,7 @@ func TestVersionedKV_Metadata_Delete(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.DeleteOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -608,7 +608,7 @@ func TestVersionedKV_Metadata_Put_Empty_CustomMetadata(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -626,7 +626,7 @@ func TestVersionedKV_Metadata_Put_Empty_CustomMetadata(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.ReadOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -665,7 +665,7 @@ func TestVersionedKV_Metadata_Put_Merge_Behavior(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -683,7 +683,7 @@ func TestVersionedKV_Metadata_Put_Merge_Behavior(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.ReadOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -732,7 +732,7 @@ func TestVersionedKV_Metadata_Put_Merge_Behavior(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -750,7 +750,7 @@ func TestVersionedKV_Metadata_Put_Merge_Behavior(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.ReadOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -798,7 +798,7 @@ func TestVersionedKV_Metadata_Put_Merge_Behavior(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -817,7 +817,7 @@ func TestVersionedKV_Metadata_Put_Merge_Behavior(t *testing.T) {
 
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.ReadOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -860,7 +860,7 @@ func TestVersionedKV_Metadata_Put_Merge_Behavior(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -878,7 +878,7 @@ func TestVersionedKV_Metadata_Put_Merge_Behavior(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.ReadOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -1084,7 +1084,7 @@ func TestVersionedKV_Metadata_Patch_CasRequiredWarning(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -1105,7 +1105,7 @@ func TestVersionedKV_Metadata_Patch_CasRequiredWarning(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -1126,7 +1126,7 @@ func TestVersionedKV_Metadata_Patch_CasRequiredWarning(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.PatchOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -1149,7 +1149,7 @@ func TestVersionedKV_Metadata_Patch_CasRequiredWarning(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.PatchOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -1248,7 +1248,7 @@ func TestVersionedKV_Metadata_Patch_CustomMetadata(t *testing.T) {
 			}
 			schema.ValidateResponse(
 				t,
-				schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+				schema.FindResponseSchema(t, paths, 0, req.Operation),
 				resp,
 				true,
 			)
@@ -1269,7 +1269,7 @@ func TestVersionedKV_Metadata_Patch_CustomMetadata(t *testing.T) {
 			}
 			schema.ValidateResponse(
 				t,
-				schema.FindResponseSchema(t, paths, 0, logical.PatchOperation),
+				schema.FindResponseSchema(t, paths, 0, req.Operation),
 				resp,
 				true,
 			)
@@ -1287,7 +1287,7 @@ func TestVersionedKV_Metadata_Patch_CustomMetadata(t *testing.T) {
 			}
 			schema.ValidateResponse(
 				t,
-				schema.FindResponseSchema(t, paths, 0, logical.ReadOperation),
+				schema.FindResponseSchema(t, paths, 0, req.Operation),
 				resp,
 				true,
 			)
@@ -1376,7 +1376,7 @@ func TestVersionedKV_Metadata_Patch_Success(t *testing.T) {
 			}
 			schema.ValidateResponse(
 				t,
-				schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+				schema.FindResponseSchema(t, paths, 0, req.Operation),
 				resp,
 				true,
 			)
@@ -1394,7 +1394,7 @@ func TestVersionedKV_Metadata_Patch_Success(t *testing.T) {
 			}
 			schema.ValidateResponse(
 				t,
-				schema.FindResponseSchema(t, paths, 0, logical.ReadOperation),
+				schema.FindResponseSchema(t, paths, 0, req.Operation),
 				resp,
 				true,
 			)
@@ -1415,7 +1415,7 @@ func TestVersionedKV_Metadata_Patch_Success(t *testing.T) {
 			}
 			schema.ValidateResponse(
 				t,
-				schema.FindResponseSchema(t, paths, 0, logical.PatchOperation),
+				schema.FindResponseSchema(t, paths, 0, req.Operation),
 				resp,
 				true,
 			)
@@ -1433,7 +1433,7 @@ func TestVersionedKV_Metadata_Patch_Success(t *testing.T) {
 			}
 			schema.ValidateResponse(
 				t,
-				schema.FindResponseSchema(t, paths, 0, logical.ReadOperation),
+				schema.FindResponseSchema(t, paths, 0, req.Operation),
 				resp,
 				true,
 			)
@@ -1491,7 +1491,7 @@ func TestVersionedKV_Metadata_Patch_NilsUnset(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.CreateOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -1509,7 +1509,7 @@ func TestVersionedKV_Metadata_Patch_NilsUnset(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.ReadOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -1534,7 +1534,7 @@ func TestVersionedKV_Metadata_Patch_NilsUnset(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.PatchOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -1552,7 +1552,7 @@ func TestVersionedKV_Metadata_Patch_NilsUnset(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.ReadOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)

--- a/path_subkeys_test.go
+++ b/path_subkeys_test.go
@@ -79,7 +79,7 @@ func TestVersionedKV_Subkeys_CurrentVersion(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.ReadOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -179,7 +179,7 @@ func TestVersionedKV_Subkeys_VersionParam(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.ReadOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -353,7 +353,7 @@ func TestVersionedKV_Subkeys_DepthParam(t *testing.T) {
 			if tc.expected != nil {
 				schema.ValidateResponse(
 					t,
-					schema.FindResponseSchema(t, paths, 0, logical.ReadOperation),
+					schema.FindResponseSchema(t, paths, 0, req.Operation),
 					resp,
 					true,
 				)
@@ -398,7 +398,7 @@ func TestVersionedKV_Subkeys_EmptyData(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.ReadOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)
@@ -443,7 +443,7 @@ func TestVersionedKV_Subkeys_VersionDeleted(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, logical.ReadOperation),
+		schema.FindResponseSchema(t, paths, 0, req.Operation),
 		resp,
 		true,
 	)


### PR DESCRIPTION
# Overview

This pull request makes the schema validation tests a little less brittle by referencing the `req.Operation` from the corresponding request rather than hard-coding it.

# Related Issues/Pull Requests

- [VAULT-12113](https://hashicorp.atlassian.net/browse/VAULT-12113)
- https://github.com/hashicorp/vault-plugin-secrets-kv/pull/76
- https://github.com/hashicorp/vault-plugin-secrets-kv/pull/78


[VAULT-12113]: https://hashicorp.atlassian.net/browse/VAULT-12113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ