### PR TITLE
Improve schema validation tests

### DIFF
--- a/passthrough_test.go
+++ b/passthrough_test.go
@@ -56,7 +56,7 @@ func TestPassthroughBackend_Write(t *testing.T) {
 		}
 		schema.ValidateResponse(
 			t,
-			schema.FindResponseSchema(t, b.(*PassthroughBackend).Paths, 0, req.Operation),
+			schema.GetResponseSchema(t, b.(*PassthroughBackend).Route(req.Path), req.Operation),
 			resp,
 			true,
 		)
@@ -104,7 +104,7 @@ func TestPassthroughBackend_Read(t *testing.T) {
 		}
 		schema.ValidateResponse(
 			t,
-			schema.FindResponseSchema(t, b.(*PassthroughBackend).Paths, 0, req.Operation),
+			schema.GetResponseSchema(t, b.(*PassthroughBackend).Route(req.Path), req.Operation),
 			resp,
 			true,
 		)
@@ -184,7 +184,7 @@ func TestPassthroughBackend_Delete(t *testing.T) {
 			}
 			schema.ValidateResponse(
 				t,
-				schema.FindResponseSchema(t, b.(*PassthroughBackend).Paths, 0, req.Operation),
+				schema.GetResponseSchema(t, b.(*PassthroughBackend).Route(req.Path), req.Operation),
 				resp,
 				true,
 			)
@@ -200,7 +200,7 @@ func TestPassthroughBackend_Delete(t *testing.T) {
 			}
 			schema.ValidateResponse(
 				t,
-				schema.FindResponseSchema(t, b.(*PassthroughBackend).Paths, 0, req.Operation),
+				schema.GetResponseSchema(t, b.(*PassthroughBackend).Route(req.Path), req.Operation),
 				resp,
 				true,
 			)
@@ -230,7 +230,7 @@ func TestPassthroughBackend_List(t *testing.T) {
 		}
 		schema.ValidateResponse(
 			t,
-			schema.FindResponseSchema(t, b.(*PassthroughBackend).Paths, 0, req.Operation),
+			schema.GetResponseSchema(t, b.(*PassthroughBackend).Route(req.Path), req.Operation),
 			resp,
 			true,
 		)

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -9,15 +9,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/testhelpers/schema"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
 func TestVersionedKV_Config(t *testing.T) {
 	b, storage, events := getBackendWithEvents(t)
-
-	paths := []*framework.Path{pathConfig(b.(*versionedKVBackend))}
 
 	d := 5 * time.Minute
 	data := map[string]interface{}{
@@ -39,7 +36,7 @@ func TestVersionedKV_Config(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -56,7 +53,7 @@ func TestVersionedKV_Config(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -111,8 +108,6 @@ func TestVersionedKV_Config_DeleteVersionAfter(t *testing.T) {
 
 			b, storage := getBackend(t)
 
-			paths := []*framework.Path{pathConfig(b.(*versionedKVBackend))}
-
 			// default value should be 0
 			req := &logical.Request{
 				Operation: logical.ReadOperation,
@@ -123,7 +118,7 @@ func TestVersionedKV_Config_DeleteVersionAfter(t *testing.T) {
 			wantResponse(t, resp, err)
 			schema.ValidateResponse(
 				t,
-				schema.FindResponseSchema(t, paths, 0, req.Operation),
+				schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 				resp,
 				true,
 			)
@@ -148,7 +143,7 @@ func TestVersionedKV_Config_DeleteVersionAfter(t *testing.T) {
 			wantNoResponse(t, resp, err)
 			schema.ValidateResponse(
 				t,
-				schema.FindResponseSchema(t, paths, 0, req.Operation),
+				schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 				resp,
 				true,
 			)
@@ -162,7 +157,7 @@ func TestVersionedKV_Config_DeleteVersionAfter(t *testing.T) {
 			wantResponse(t, resp, err)
 			schema.ValidateResponse(
 				t,
-				schema.FindResponseSchema(t, paths, 0, req.Operation),
+				schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 				resp,
 				true,
 			)
@@ -188,7 +183,7 @@ func TestVersionedKV_Config_DeleteVersionAfter(t *testing.T) {
 			wantNoResponse(t, resp, err)
 			schema.ValidateResponse(
 				t,
-				schema.FindResponseSchema(t, paths, 0, req.Operation),
+				schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 				resp,
 				true,
 			)
@@ -202,7 +197,7 @@ func TestVersionedKV_Config_DeleteVersionAfter(t *testing.T) {
 			wantResponse(t, resp, err)
 			schema.ValidateResponse(
 				t,
-				schema.FindResponseSchema(t, paths, 0, req.Operation),
+				schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 				resp,
 				true,
 			)

--- a/path_data_test.go
+++ b/path_data_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/go-test/deep"
 	log "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/helper/testhelpers/schema"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -86,8 +85,6 @@ func expectedMetadataKeys() map[string]struct{} {
 func TestVersionedKV_Data_Put(t *testing.T) {
 	b, storage, events := getBackendWithEvents(t)
 
-	paths := []*framework.Path{pathData(b.(*versionedKVBackend))}
-
 	customMetadata := map[string]string{
 		"foo": "abc",
 		"bar": "def",
@@ -128,7 +125,7 @@ func TestVersionedKV_Data_Put(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -167,7 +164,7 @@ func TestVersionedKV_Data_Put(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -194,8 +191,6 @@ func TestVersionedKV_Data_Put(t *testing.T) {
 func TestVersionedKV_Data_Put_ZeroCas(t *testing.T) {
 	b, storage := getBackend(t)
 
-	paths := []*framework.Path{pathData(b.(*versionedKVBackend))}
-
 	data := map[string]interface{}{
 		"data": map[string]interface{}{
 			"bar": "baz",
@@ -218,7 +213,7 @@ func TestVersionedKV_Data_Put_ZeroCas(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -244,8 +239,6 @@ func TestVersionedKV_Data_Put_ZeroCas(t *testing.T) {
 
 func TestVersionedKV_Data_Get(t *testing.T) {
 	b, storage := getBackend(t)
-
-	paths := []*framework.Path{pathData(b.(*versionedKVBackend))}
 
 	req := &logical.Request{
 		Operation: logical.ReadOperation,
@@ -302,7 +295,7 @@ func TestVersionedKV_Data_Get(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -323,7 +316,7 @@ func TestVersionedKV_Data_Get(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -363,8 +356,6 @@ func TestVersionedKV_Data_Get(t *testing.T) {
 func TestVersionedKV_Data_Delete(t *testing.T) {
 	b, storage, events := getBackendWithEvents(t)
 
-	paths := []*framework.Path{pathData(b.(*versionedKVBackend))}
-
 	data := map[string]interface{}{
 		"data": map[string]interface{}{
 			"bar": "baz",
@@ -384,7 +375,7 @@ func TestVersionedKV_Data_Delete(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -405,7 +396,7 @@ func TestVersionedKV_Data_Delete(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -449,8 +440,6 @@ func TestVersionedKV_Data_Delete(t *testing.T) {
 func TestVersionedKV_Data_Put_CleanupOldVersions(t *testing.T) {
 	b, storage := getBackend(t)
 
-	paths := []*framework.Path{pathData(b.(*versionedKVBackend))}
-
 	// Write 10 versions
 	for i := 0; i < 10; i++ {
 		data := map[string]interface{}{
@@ -472,7 +461,7 @@ func TestVersionedKV_Data_Put_CleanupOldVersions(t *testing.T) {
 		}
 		schema.ValidateResponse(
 			t,
-			schema.FindResponseSchema(t, paths, 0, req.Operation),
+			schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 			resp,
 			true,
 		)
@@ -520,7 +509,7 @@ func TestVersionedKV_Data_Put_CleanupOldVersions(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -551,8 +540,6 @@ func TestVersionedKV_Data_Put_CleanupOldVersions(t *testing.T) {
 func TestVersionedKV_Data_Patch_CleanupOldVersions(t *testing.T) {
 	b, storage := getBackend(t)
 
-	paths := []*framework.Path{pathData(b.(*versionedKVBackend))}
-
 	// Write 10 versions
 	for i := 0; i < 10; i++ {
 		data := map[string]interface{}{
@@ -574,7 +561,7 @@ func TestVersionedKV_Data_Patch_CleanupOldVersions(t *testing.T) {
 		}
 		schema.ValidateResponse(
 			t,
-			schema.FindResponseSchema(t, paths, 0, req.Operation),
+			schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 			resp,
 			true,
 		)
@@ -622,7 +609,7 @@ func TestVersionedKV_Data_Patch_CleanupOldVersions(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -653,8 +640,6 @@ func TestVersionedKV_Data_Patch_CleanupOldVersions(t *testing.T) {
 func TestVersionedKV_Reload_Policy(t *testing.T) {
 	b, storage := getBackend(t)
 
-	paths := []*framework.Path{pathData(b.(*versionedKVBackend))}
-
 	data := map[string]interface{}{
 		"data": map[string]interface{}{
 			"bar": "baz",
@@ -677,7 +662,7 @@ func TestVersionedKV_Reload_Policy(t *testing.T) {
 		}
 		schema.ValidateResponse(
 			t,
-			schema.FindResponseSchema(t, paths, 0, req.Operation),
+			schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 			resp,
 			true,
 		)
@@ -709,7 +694,7 @@ func TestVersionedKV_Reload_Policy(t *testing.T) {
 		}
 		schema.ValidateResponse(
 			t,
-			schema.FindResponseSchema(t, paths, 0, req.Operation),
+			schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 			resp,
 			true,
 		)
@@ -785,8 +770,6 @@ func TestVersionedKV_Patch_NotFound(t *testing.T) {
 func TestVersionedKV_Patch_CASValidation(t *testing.T) {
 	b, storage := getBackend(t)
 
-	paths := []*framework.Path{pathData(b.(*versionedKVBackend))}
-
 	config := map[string]interface{}{
 		"cas_required": true,
 	}
@@ -825,7 +808,7 @@ func TestVersionedKV_Patch_CASValidation(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -893,7 +876,6 @@ func TestVersionedKV_Patch_CASValidation(t *testing.T) {
 func TestVersionedKV_Patch_NoData(t *testing.T) {
 	b, storage := getBackend(t)
 
-	paths := []*framework.Path{pathData(b.(*versionedKVBackend))}
 	data := map[string]interface{}{
 		"data": map[string]interface{}{
 			"bar": "baz",
@@ -913,7 +895,7 @@ func TestVersionedKV_Patch_NoData(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -944,8 +926,6 @@ func TestVersionedKV_Patch_NoData(t *testing.T) {
 
 func TestVersionedKV_Patch_Success(t *testing.T) {
 	b, storage, events := getBackendWithEvents(t)
-
-	paths := []*framework.Path{pathData(b.(*versionedKVBackend))}
 
 	customMetadata := map[string]string{
 		"foo": "abc",
@@ -990,7 +970,7 @@ func TestVersionedKV_Patch_Success(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -1030,7 +1010,7 @@ func TestVersionedKV_Patch_Success(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -1056,7 +1036,7 @@ func TestVersionedKV_Patch_Success(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -1084,8 +1064,6 @@ func TestVersionedKV_Patch_Success(t *testing.T) {
 func TestVersionedKV_Patch_CurrentVersionDeleted(t *testing.T) {
 	b, storage := getBackend(t)
 
-	paths := []*framework.Path{pathData(b.(*versionedKVBackend))}
-
 	data := map[string]interface{}{
 		"data": map[string]interface{}{
 			"bar": "baz",
@@ -1105,7 +1083,7 @@ func TestVersionedKV_Patch_CurrentVersionDeleted(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -1123,7 +1101,7 @@ func TestVersionedKV_Patch_CurrentVersionDeleted(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -1207,8 +1185,6 @@ func TestVersionedKV_Patch_CurrentVersionDeleted(t *testing.T) {
 func TestVersionedKV_Patch_CurrentVersionDestroyed(t *testing.T) {
 	b, storage := getBackend(t)
 
-	paths := []*framework.Path{pathData(b.(*versionedKVBackend))}
-
 	data := map[string]interface{}{
 		"data": map[string]interface{}{
 			"bar": "baz",
@@ -1228,7 +1204,7 @@ func TestVersionedKV_Patch_CurrentVersionDestroyed(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)

--- a/path_delete_test.go
+++ b/path_delete_test.go
@@ -15,8 +15,6 @@ import (
 func TestVersionedKV_Delete_Put(t *testing.T) {
 	b, storage, events := getBackendWithEvents(t)
 
-	paths := pathsDelete(b.(*versionedKVBackend))
-
 	data := map[string]interface{}{
 		"data": map[string]interface{}{
 			"bar": "baz",
@@ -81,7 +79,7 @@ func TestVersionedKV_Delete_Put(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -126,8 +124,6 @@ func TestVersionedKV_Delete_Put(t *testing.T) {
 func TestVersionedKV_Undelete_Put(t *testing.T) {
 	b, storage, events := getBackendWithEvents(t)
 
-	paths := pathsDelete(b.(*versionedKVBackend))
-
 	data := map[string]interface{}{
 		"data": map[string]interface{}{
 			"bar": "baz",
@@ -192,7 +188,7 @@ func TestVersionedKV_Undelete_Put(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -214,7 +210,7 @@ func TestVersionedKV_Undelete_Put(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 1, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)

--- a/path_destroy_test.go
+++ b/path_destroy_test.go
@@ -7,15 +7,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/testhelpers/schema"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
 func TestVersionedKV_Destroy_Put(t *testing.T) {
 	b, storage, events := getBackendWithEvents(t)
-
-	paths := []*framework.Path{pathDestroy(b.(*versionedKVBackend))}
 
 	data := map[string]interface{}{
 		"data": map[string]interface{}{
@@ -81,7 +78,7 @@ func TestVersionedKV_Destroy_Put(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)

--- a/path_metadata_test.go
+++ b/path_metadata_test.go
@@ -11,15 +11,12 @@ import (
 	"time"
 
 	"github.com/go-test/deep"
-	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/testhelpers/schema"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
 func TestVersionedKV_Metadata_Put(t *testing.T) {
 	b, storage := getBackend(t)
-
-	paths := []*framework.Path{pathMetadata(b.(*versionedKVBackend))}
 
 	d := 5 * time.Minute
 
@@ -48,7 +45,7 @@ func TestVersionedKV_Metadata_Put(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -65,7 +62,7 @@ func TestVersionedKV_Metadata_Put(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -192,7 +189,7 @@ func TestVersionedKV_Metadata_Put(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -233,7 +230,7 @@ func TestVersionedKV_Metadata_Put(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -273,7 +270,7 @@ func TestVersionedKV_Metadata_Put(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -297,8 +294,6 @@ func TestVersionedKV_Metadata_Put(t *testing.T) {
 
 func TestVersionedKV_Metadata_Delete(t *testing.T) {
 	b, storage, events := getBackendWithEvents(t)
-
-	paths := []*framework.Path{pathMetadata(b.(*versionedKVBackend))}
 
 	// Create a few versions
 	for i := 0; i <= 5; i++ {
@@ -337,7 +332,7 @@ func TestVersionedKV_Metadata_Delete(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -597,8 +592,6 @@ func TestVersionedKv_Metadata_Put_Too_Many_CustomMetadata_Keys(t *testing.T) {
 func TestVersionedKV_Metadata_Put_Empty_CustomMetadata(t *testing.T) {
 	b, storage := getBackend(t)
 
-	paths := []*framework.Path{pathMetadata(b.(*versionedKVBackend))}
-
 	metadataPath := "metadata/foo"
 
 	data := map[string]interface{}{
@@ -619,7 +612,7 @@ func TestVersionedKV_Metadata_Put_Empty_CustomMetadata(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -637,7 +630,7 @@ func TestVersionedKV_Metadata_Put_Empty_CustomMetadata(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -650,8 +643,6 @@ func TestVersionedKV_Metadata_Put_Empty_CustomMetadata(t *testing.T) {
 
 func TestVersionedKV_Metadata_Put_Merge_Behavior(t *testing.T) {
 	b, storage := getBackend(t)
-
-	paths := []*framework.Path{pathMetadata(b.(*versionedKVBackend))}
 
 	metadataPath := "metadata/foo"
 	expectedMaxVersions := uint32(5)
@@ -676,7 +667,7 @@ func TestVersionedKV_Metadata_Put_Merge_Behavior(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -694,7 +685,7 @@ func TestVersionedKV_Metadata_Put_Merge_Behavior(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -743,7 +734,7 @@ func TestVersionedKV_Metadata_Put_Merge_Behavior(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -761,7 +752,7 @@ func TestVersionedKV_Metadata_Put_Merge_Behavior(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -809,7 +800,7 @@ func TestVersionedKV_Metadata_Put_Merge_Behavior(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -828,7 +819,7 @@ func TestVersionedKV_Metadata_Put_Merge_Behavior(t *testing.T) {
 
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -871,7 +862,7 @@ func TestVersionedKV_Metadata_Put_Merge_Behavior(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -889,7 +880,7 @@ func TestVersionedKV_Metadata_Put_Merge_Behavior(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -1077,8 +1068,6 @@ func TestVersionedKV_Metadata_Patch_NotFound(t *testing.T) {
 func TestVersionedKV_Metadata_Patch_CasRequiredWarning(t *testing.T) {
 	b, storage := getBackend(t)
 
-	paths := []*framework.Path{pathMetadata(b.(*versionedKVBackend))}
-
 	req := &logical.Request{
 		Operation: logical.UpdateOperation,
 		Path:      "config",
@@ -1095,7 +1084,7 @@ func TestVersionedKV_Metadata_Patch_CasRequiredWarning(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -1116,7 +1105,7 @@ func TestVersionedKV_Metadata_Patch_CasRequiredWarning(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -1137,7 +1126,7 @@ func TestVersionedKV_Metadata_Patch_CasRequiredWarning(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -1160,7 +1149,7 @@ func TestVersionedKV_Metadata_Patch_CasRequiredWarning(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -1239,8 +1228,6 @@ func TestVersionedKV_Metadata_Patch_CustomMetadata(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			b, storage := getBackend(t)
 
-			paths := []*framework.Path{pathMetadata(b.(*versionedKVBackend))}
-
 			path := "metadata/" + tc.name
 
 			req := &logical.Request{
@@ -1259,7 +1246,7 @@ func TestVersionedKV_Metadata_Patch_CustomMetadata(t *testing.T) {
 			}
 			schema.ValidateResponse(
 				t,
-				schema.FindResponseSchema(t, paths, 0, req.Operation),
+				schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 				resp,
 				true,
 			)
@@ -1280,7 +1267,7 @@ func TestVersionedKV_Metadata_Patch_CustomMetadata(t *testing.T) {
 			}
 			schema.ValidateResponse(
 				t,
-				schema.FindResponseSchema(t, paths, 0, req.Operation),
+				schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 				resp,
 				true,
 			)
@@ -1298,7 +1285,7 @@ func TestVersionedKV_Metadata_Patch_CustomMetadata(t *testing.T) {
 			}
 			schema.ValidateResponse(
 				t,
-				schema.FindResponseSchema(t, paths, 0, req.Operation),
+				schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 				resp,
 				true,
 			)
@@ -1366,8 +1353,6 @@ func TestVersionedKV_Metadata_Patch_Success(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			b, storage, events := getBackendWithEvents(t)
 
-			paths := []*framework.Path{pathMetadata(b.(*versionedKVBackend))}
-
 			path := "metadata/" + tc.name
 
 			req := &logical.Request{
@@ -1387,7 +1372,7 @@ func TestVersionedKV_Metadata_Patch_Success(t *testing.T) {
 			}
 			schema.ValidateResponse(
 				t,
-				schema.FindResponseSchema(t, paths, 0, req.Operation),
+				schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 				resp,
 				true,
 			)
@@ -1405,7 +1390,7 @@ func TestVersionedKV_Metadata_Patch_Success(t *testing.T) {
 			}
 			schema.ValidateResponse(
 				t,
-				schema.FindResponseSchema(t, paths, 0, req.Operation),
+				schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 				resp,
 				true,
 			)
@@ -1426,7 +1411,7 @@ func TestVersionedKV_Metadata_Patch_Success(t *testing.T) {
 			}
 			schema.ValidateResponse(
 				t,
-				schema.FindResponseSchema(t, paths, 0, req.Operation),
+				schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 				resp,
 				true,
 			)
@@ -1444,7 +1429,7 @@ func TestVersionedKV_Metadata_Patch_Success(t *testing.T) {
 			}
 			schema.ValidateResponse(
 				t,
-				schema.FindResponseSchema(t, paths, 0, req.Operation),
+				schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 				resp,
 				true,
 			)
@@ -1487,8 +1472,6 @@ func TestVersionedKV_Metadata_Patch_Success(t *testing.T) {
 func TestVersionedKV_Metadata_Patch_NilsUnset(t *testing.T) {
 	b, storage := getBackend(t)
 
-	paths := []*framework.Path{pathMetadata(b.(*versionedKVBackend))}
-
 	path := "metadata/nils_unset"
 
 	req := &logical.Request{
@@ -1507,7 +1490,7 @@ func TestVersionedKV_Metadata_Patch_NilsUnset(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -1525,7 +1508,7 @@ func TestVersionedKV_Metadata_Patch_NilsUnset(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -1550,7 +1533,7 @@ func TestVersionedKV_Metadata_Patch_NilsUnset(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -1568,7 +1551,7 @@ func TestVersionedKV_Metadata_Patch_NilsUnset(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)

--- a/path_subkeys_test.go
+++ b/path_subkeys_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/testhelpers/schema"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -36,8 +35,6 @@ func TestVersionedKV_Subkeys_NotFound(t *testing.T) {
 // version of an entry is read if the version param is not provided
 func TestVersionedKV_Subkeys_CurrentVersion(t *testing.T) {
 	b, storage := getBackend(t)
-
-	paths := []*framework.Path{pathSubkeys(b.(*versionedKVBackend))}
 
 	data := map[string]interface{}{
 		"data": map[string]interface{}{
@@ -82,7 +79,7 @@ func TestVersionedKV_Subkeys_CurrentVersion(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -132,8 +129,6 @@ func TestVersionedKV_Subkeys_CurrentVersion(t *testing.T) {
 func TestVersionedKV_Subkeys_VersionParam(t *testing.T) {
 	b, storage := getBackend(t)
 
-	paths := []*framework.Path{pathSubkeys(b.(*versionedKVBackend))}
-
 	req := &logical.Request{
 		Operation: logical.CreateOperation,
 		Path:      "data/foo",
@@ -182,7 +177,7 @@ func TestVersionedKV_Subkeys_VersionParam(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -309,8 +304,6 @@ func TestVersionedKV_Subkeys_DepthParam(t *testing.T) {
 
 			b, storage := getBackend(t)
 
-			paths := []*framework.Path{pathSubkeys(b.(*versionedKVBackend))}
-
 			req := &logical.Request{
 				Operation: logical.CreateOperation,
 				Path:      "data/foo",
@@ -356,7 +349,7 @@ func TestVersionedKV_Subkeys_DepthParam(t *testing.T) {
 			if tc.expected != nil {
 				schema.ValidateResponse(
 					t,
-					schema.FindResponseSchema(t, paths, 0, req.Operation),
+					schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 					resp,
 					true,
 				)
@@ -372,8 +365,6 @@ func TestVersionedKV_Subkeys_DepthParam(t *testing.T) {
 // returned if the underlying data is also empty
 func TestVersionedKV_Subkeys_EmptyData(t *testing.T) {
 	b, storage := getBackend(t)
-
-	paths := []*framework.Path{pathSubkeys(b.(*versionedKVBackend))}
 
 	req := &logical.Request{
 		Operation: logical.CreateOperation,
@@ -401,7 +392,7 @@ func TestVersionedKV_Subkeys_EmptyData(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)
@@ -415,8 +406,6 @@ func TestVersionedKV_Subkeys_EmptyData(t *testing.T) {
 // is returned if the requested entry has been deleted
 func TestVersionedKV_Subkeys_VersionDeleted(t *testing.T) {
 	b, storage := getBackend(t)
-
-	paths := []*framework.Path{pathSubkeys(b.(*versionedKVBackend))}
 
 	req := &logical.Request{
 		Operation: logical.CreateOperation,
@@ -446,7 +435,7 @@ func TestVersionedKV_Subkeys_VersionDeleted(t *testing.T) {
 	}
 	schema.ValidateResponse(
 		t,
-		schema.FindResponseSchema(t, paths, 0, req.Operation),
+		schema.GetResponseSchema(t, b.(*versionedKVBackend).Route(req.Path), req.Operation),
 		resp,
 		true,
 	)


### PR DESCRIPTION
# Overview

This pull request makes the schema validation tests a little less brittle by using `schema.GetResponseSchema(t, b.Route(...), ...)` instead of `schema.FindResponseSchema(...)`. Now, adding a new path will not break the tests. This is also consistent with the way we are doing schema validation in https://github.com/hashicorp/vault/.
