### PR TITLE
Remove redundant OpenAPI response definitions for list operations

### DIFF
--- a/passthrough.go
+++ b/passthrough.go
@@ -120,17 +120,6 @@ func LeaseSwitchedPassthroughBackend(ctx context.Context, conf *logical.BackendC
 						DisplayAttrs: &framework.DisplayAttributes{
 							OperationVerb: "list",
 						},
-						Responses: map[int][]framework.Response{
-							http.StatusOK: {{
-								Description: http.StatusText(http.StatusOK),
-								Fields: map[string]*framework.FieldSchema{
-									"keys": {
-										Type:     framework.TypeStringSlice,
-										Required: true,
-									},
-								},
-							}},
-						},
 					},
 				},
 

--- a/path_metadata.go
+++ b/path_metadata.go
@@ -142,17 +142,6 @@ version-agnostic information about a secret.
 			},
 			logical.ListOperation: &framework.PathOperation{
 				Callback: b.upgradeCheck(b.pathMetadataList()),
-				Responses: map[int][]framework.Response{
-					http.StatusOK: {{
-						Description: http.StatusText(http.StatusOK),
-						Fields: map[string]*framework.FieldSchema{
-							"keys": {
-								Type:     framework.TypeStringSlice,
-								Required: true,
-							},
-						},
-					}},
-				},
 			},
 			logical.PatchOperation: &framework.PathOperation{
 				Callback: b.upgradeCheck(b.pathMetadataPatch()),


### PR DESCRIPTION
hashicorp/vault#21934 implements this centrally
