### PR TITLE
The KVv1 write API should be marked as TakesArbitraryInput

### DIFF
--- a/passthrough.go
+++ b/passthrough.go
@@ -69,6 +69,8 @@ func LeaseSwitchedPassthroughBackend(ctx context.Context, conf *logical.BackendC
 					},
 				},
 
+				TakesArbitraryInput: true,
+
 				Operations: map[logical.Operation]framework.OperationHandler{
 					logical.ReadOperation: &framework.PathOperation{
 						Callback: b.handleRead(),


### PR DESCRIPTION
* because it does

* because hashicorp/vault#21946 aims to fix unknown parameter warnings
  not being generated on endpoints returning empty responses, after
  which all KV v1 writes would generate incorrect warnings without this
  correction

* because we might want to rely on this flag to arrange for correct
  OpenAPI client library generation - currently the `KvV1Write` function
  in the generated client library is inoperable
