### PR TITLE
chore: add errcheck for parsing cli flags

### DIFF
--- a/cmd/vault-plugin-secrets-kv/main.go
+++ b/cmd/vault-plugin-secrets-kv/main.go
@@ -15,21 +15,26 @@ import (
 func main() {
 	apiClientMeta := &api.PluginAPIClientMeta{}
 	flags := apiClientMeta.FlagSet()
-	flags.Parse(os.Args[1:])
+
+	if err := flags.Parse(os.Args[1:]); err != nil {
+		fatal(err)
+	}
 
 	tlsConfig := apiClientMeta.GetTLSConfig()
 	tlsProviderFunc := api.VaultPluginTLSProvider(tlsConfig)
 
-	err := plugin.ServeMultiplex(&plugin.ServeOpts{
+	if err := plugin.ServeMultiplex(&plugin.ServeOpts{
 		BackendFactoryFunc: kv.Factory,
 		// set the TLSProviderFunc so that the plugin maintains backwards
 		// compatibility with Vault versions that don’t support plugin AutoMTLS
 		TLSProviderFunc: tlsProviderFunc,
-	})
-	if err != nil {
-		logger := hclog.New(&hclog.LoggerOptions{})
-
-		logger.Error("plugin shutting down", "error", err)
-		os.Exit(1)
+	}); err != nil {
+		fatal(err)
 	}
+}
+
+func fatal(err error) {
+	logger := hclog.New(&hclog.LoggerOptions{})
+	logger.Error("plugin shutting down", "error", err)
+	os.Exit(1)
 }


### PR DESCRIPTION
# Overview

Add missing error check to `main()` for parsing CLI flags. If `flags.Parse()` fails now the error is hidden from the user.

# Design of Change

An error check was missing and I added it 👍 

# Related Issues/Pull Requests

Originally noticed at https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/202. Same issue seems to apply to various plugin implementations.

# Contributor Checklist

[-] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
None needed

[-] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
None needed

[x] Backwards compatible
