### PR TITLE
Remove unused code

### DIFF
--- a/passthrough.go
+++ b/passthrough.go
@@ -17,14 +17,6 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-type Passthrough interface {
-	handleRead() framework.OperationFunc
-	handleWrite() framework.OperationFunc
-	handleDelete() framework.OperationFunc
-	handleList() framework.OperationFunc
-	handleExistenceCheck() framework.ExistenceFunc
-}
-
 // PassthroughBackendFactory returns a PassthroughBackend
 // with leases switched off
 func PassthroughBackendFactory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
@@ -250,10 +242,6 @@ func (b *PassthroughBackend) handleRead() framework.OperationFunc {
 
 		return resp, nil
 	}
-}
-
-func (b *PassthroughBackend) GeneratesLeases() bool {
-	return b.generateLeases
 }
 
 func (b *PassthroughBackend) handleWrite() framework.OperationFunc {


### PR DESCRIPTION
The `Passthrough` interface ceased to be used after some code was
removed in #11.

The `GenerateLeases` function ceased to be used when this code was
made capable of being a separate plugin, rather than a builtin part of
Vault - credit to @remilapeyre for noticing this in #55 - I'm just
cherrypicking the removal of unused code from that old unmerged PR,
whilst I had some other unused code to PR the removal of too.
