### PR TITLE
+ added versions to delete & undelete events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 IMPROVEMENTS:
 
 * Add display attributes for OpenAPI OperationID's [GH-104](https://github.com/hashicorp/vault-plugin-secrets-kv/pull/104)
+* Add versions to delete and undelete events [GH-122](https://github.com/hashicorp/vault-plugin-secrets-kv/pull/122)

--- a/path_delete.go
+++ b/path_delete.go
@@ -5,6 +5,7 @@ package kv
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -138,10 +139,15 @@ func (b *versionedKVBackend) pathUndeleteWrite() framework.OperationFunc {
 		if err != nil {
 			return nil, err
 		}
+		marshaledVersions, err := json.Marshal(&versions)
+		if err != nil {
+			return nil, err
+		}
 		kvEvent(ctx, b.Backend, 2, "undelete",
 			"path", "undelete/"+key,
 			"current_version", fmt.Sprintf("%d", meta.CurrentVersion),
 			"oldest_version", fmt.Sprintf("%d", meta.OldestVersion),
+			"undeleted_versions", string(marshaledVersions),
 		)
 		return nil, nil
 	}
@@ -195,10 +201,15 @@ func (b *versionedKVBackend) pathDeleteWrite() framework.OperationFunc {
 		if err != nil {
 			return nil, err
 		}
+		marshaledVersions, err := json.Marshal(&versions)
+		if err != nil {
+			return nil, err
+		}
 		kvEvent(ctx, b.Backend, 2, "delete",
 			"path", "delete/"+key,
 			"current_version", fmt.Sprintf("%d", meta.CurrentVersion),
 			"oldest_version", fmt.Sprintf("%d", meta.OldestVersion),
+			"deleted_versions", string(marshaledVersions),
 		)
 		return nil, nil
 	}


### PR DESCRIPTION
# Overview
Added the deleted & undeleted versions as additional metadata on these operations. Useful to know if the current (or latest) version changed for event consumers. 

# Contributor Checklist
[x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet

* Events do not seem to be documented on the KV secrets engine yet?

[x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[x] Backwards compatible
