### PR TITLE
Add `api_path`, `operation` to event metadata.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 CHANGES:
 
-* Events: now include `secret_path` and `operation` [GH-XYZ]()
+* Events: now include `secret_path` and `operation` [GH-124](https://github.com/hashicorp/vault-plugin-secrets-kv/pull/124)
 
 ## 0.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 CHANGES:
 
-* Events: now include `secret_path` and `operation` [GH-124](https://github.com/hashicorp/vault-plugin-secrets-kv/pull/124)
+* Events: now include `data_path`, `operation`, and `modified` [GH-124](https://github.com/hashicorp/vault-plugin-secrets-kv/pull/124)
 
 ## 0.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+CHANGES:
+
+* Events: now include `secret_path` and `operation` [GH-XYZ]()
+
 ## 0.15.0
 
 IMPROVEMENTS:

--- a/backend.go
+++ b/backend.go
@@ -5,7 +5,6 @@ package kv
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -20,7 +19,6 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/locksutil"
 	"github.com/hashicorp/vault/sdk/helper/salt"
 	"github.com/hashicorp/vault/sdk/logical"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
 const (
@@ -434,37 +432,23 @@ func (b *versionedKVBackend) writeKeyMetadata(ctx context.Context, s logical.Sto
 	return nil
 }
 
-func kvEvent(ctx context.Context, b *framework.Backend, kvVersion int, eventType string, metadataPairs ...string) {
-	ev, err := logical.NewEvent()
-	if err != nil {
-		b.Logger().Warn("Error creating event", "error", err)
-		return
+func kvEvent(ctx context.Context,
+	b *framework.Backend,
+	operation string,
+	secretPath string,
+	writePath string,
+	kvVersion int,
+	additionalMetadataPairs ...string) {
+
+	metadata := []string{
+		logical.EventMetadataOperation, operation,
+		logical.EventMetadataSecretPath, secretPath,
+		"path", writePath, // included for backwards compatibility
 	}
-	metadata := map[string]string{}
-	if len(metadataPairs)%2 != 0 {
-		b.Logger().Error("Odd number of metadata strings")
-		return
-	}
-	for i := 0; i < len(metadataPairs); i += 2 {
-		metadata[metadataPairs[i]] = metadataPairs[i+1]
-	}
-	metadataBytes, err := json.Marshal(metadata)
-	if err != nil {
-		b.Logger().Warn("Error marshaling metadata", "error", err)
-		return
-	}
-	ev.Metadata = &structpb.Struct{}
-	if err := ev.Metadata.UnmarshalJSON(metadataBytes); err != nil {
-		b.Logger().Warn("Error unmarshaling metadata into proto", "error", err)
-		return
-	}
-	err = b.SendEvent(ctx, logical.EventType(fmt.Sprintf("kv-v%d/%s", kvVersion, eventType)), ev)
-	// ignore events are disabled error
-	if err == framework.ErrNoEvents {
-		return
-	} else if err != nil {
-		b.Logger().Warn("Error sending event", "error", err)
-		return
+	metadata = append(metadata, additionalMetadataPairs...)
+	err := logical.SendEvent(ctx, b, fmt.Sprintf("kv-v%d/%s", kvVersion, operation), metadata...)
+	if err != nil && err != framework.ErrNoEvents {
+		b.Logger().Error("Error sending event", "error", err)
 	}
 }
 

--- a/backend.go
+++ b/backend.go
@@ -436,14 +436,13 @@ func kvEvent(ctx context.Context,
 	b *framework.Backend,
 	operation string,
 	secretPath string,
-	writePath string,
 	kvVersion int,
 	additionalMetadataPairs ...string) {
 
 	metadata := []string{
 		logical.EventMetadataOperation, operation,
-		logical.EventMetadataSecretPath, secretPath,
-		"path", writePath, // included for backwards compatibility
+		logical.EventMetadataApiPath, secretPath,
+		"path", secretPath, // included for backwards compatibility
 	}
 	metadata = append(metadata, additionalMetadataPairs...)
 	err := logical.SendEvent(ctx, b, fmt.Sprintf("kv-v%d/%s", kvVersion, operation), metadata...)

--- a/backend_test.go
+++ b/backend_test.go
@@ -41,7 +41,7 @@ func (m *mockEventsSender) expectEvents(t *testing.T, expectedEvents []expectedE
 		if expected.eventType != actual.EventType {
 			t.Fatalf("Mismatched event type at index %d. Expected %s, got %s\n%v", i, expected.eventType, actual.EventType, m.eventsProcessed)
 		}
-		actualPath := actual.Event.Metadata.Fields["secret_path"].GetStringValue()
+		actualPath := actual.Event.Metadata.Fields["api_path"].GetStringValue()
 		if expected.path != actualPath {
 			t.Fatalf("Mismatched path at index %d. Expected %s, got %s\n%v", i, expected.path, actualPath, m.eventsProcessed)
 		}

--- a/backend_test.go
+++ b/backend_test.go
@@ -13,6 +13,7 @@ import (
 type expectedEvent struct {
 	eventType string
 	path      string
+	dataPath  string
 }
 
 type mockEventsSender struct {
@@ -41,9 +42,13 @@ func (m *mockEventsSender) expectEvents(t *testing.T, expectedEvents []expectedE
 		if expected.eventType != actual.EventType {
 			t.Fatalf("Mismatched event type at index %d. Expected %s, got %s\n%v", i, expected.eventType, actual.EventType, m.eventsProcessed)
 		}
-		actualPath := actual.Event.Metadata.Fields["api_path"].GetStringValue()
+		actualPath := actual.Event.Metadata.Fields["path"].GetStringValue()
 		if expected.path != actualPath {
 			t.Fatalf("Mismatched path at index %d. Expected %s, got %s\n%v", i, expected.path, actualPath, m.eventsProcessed)
+		}
+		actualDataPath := actual.Event.Metadata.Fields["data_path"].GetStringValue()
+		if expected.dataPath != actualDataPath {
+			t.Fatalf("Mismatched data path at index %d. Expected %s, got %s\n%v", i, expected.path, actualDataPath, m.eventsProcessed)
 		}
 	}
 }

--- a/backend_test.go
+++ b/backend_test.go
@@ -19,7 +19,7 @@ type mockEventsSender struct {
 	eventsProcessed []*logical.EventReceived
 }
 
-func (m *mockEventsSender) Send(ctx context.Context, eventType logical.EventType, event *logical.EventData) error {
+func (m *mockEventsSender) SendEvent(ctx context.Context, eventType logical.EventType, event *logical.EventData) error {
 	if m == nil {
 		return nil
 	}
@@ -41,7 +41,7 @@ func (m *mockEventsSender) expectEvents(t *testing.T, expectedEvents []expectedE
 		if expected.eventType != actual.EventType {
 			t.Fatalf("Mismatched event type at index %d. Expected %s, got %s\n%v", i, expected.eventType, actual.EventType, m.eventsProcessed)
 		}
-		actualPath := actual.Event.Metadata.Fields["path"].GetStringValue()
+		actualPath := actual.Event.Metadata.Fields["secret_path"].GetStringValue()
 		if expected.path != actualPath {
 			t.Fatalf("Mismatched path at index %d. Expected %s, got %s\n%v", i, expected.path, actualPath, m.eventsProcessed)
 		}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.7
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2
 	github.com/hashicorp/vault/api v1.9.1
-	github.com/hashicorp/vault/sdk v0.9.2
+	github.com/hashicorp/vault/sdk v0.9.3-0.20230823221122-925702de10d8
 	github.com/mitchellh/mapstructure v1.5.0
 	google.golang.org/protobuf v1.30.0
 )
@@ -29,7 +29,7 @@ require (
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-kms-wrapping/entropy/v2 v2.0.0 // indirect
 	github.com/hashicorp/go-kms-wrapping/v2 v2.0.8 // indirect
-	github.com/hashicorp/go-plugin v1.4.8 // indirect
+	github.com/hashicorp/go-plugin v1.4.10 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/go-secure-stdlib/mlock v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/hashicorp/go-kms-wrapping/v2 v2.0.8/go.mod h1:qTCjxGig/kjuj3hk1z8pOUr
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
-github.com/hashicorp/go-plugin v1.4.8 h1:CHGwpxYDOttQOY7HOWgETU9dyVjOXzniXDqJcYJE1zM=
-github.com/hashicorp/go-plugin v1.4.8/go.mod h1:viDMjcLJuDui6pXb8U4HVfb8AamCWhHGUjr2IrTF67s=
+github.com/hashicorp/go-plugin v1.4.10 h1:xUbmA4jC6Dq163/fWcp8P3JuHilrHHMLNRxzGQJ9hNk=
+github.com/hashicorp/go-plugin v1.4.10/go.mod h1:6/1TEzT0eQznvI/gV2CM29DLSkAK/e58mUWKVsPaph0=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-retryablehttp v0.7.1 h1:sUiuQAnLlbvmExtFQs72iFW/HXeUn8Z1aJLQ4LJJbTQ=
 github.com/hashicorp/go-retryablehttp v0.7.1/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
@@ -99,8 +99,8 @@ github.com/hashicorp/hcl v1.0.1-vault-5 h1:kI3hhbbyzr4dldA8UdTb7ZlVVlI2DACdCfz31
 github.com/hashicorp/hcl v1.0.1-vault-5/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=
 github.com/hashicorp/vault/api v1.9.1 h1:LtY/I16+5jVGU8rufyyAkwopgq/HpUnxFBg+QLOAV38=
 github.com/hashicorp/vault/api v1.9.1/go.mod h1:78kktNcQYbBGSrOjQfHjXN32OhhxXnbYl3zxpd2uPUs=
-github.com/hashicorp/vault/sdk v0.9.2 h1:H1kitfl1rG2SHbeGEyvhEqmIjVKE3E6c2q3ViKOs6HA=
-github.com/hashicorp/vault/sdk v0.9.2/go.mod h1:gG0lA7P++KefplzvcD3vrfCmgxVAM7Z/SqX5NeOL/98=
+github.com/hashicorp/vault/sdk v0.9.3-0.20230823221122-925702de10d8 h1:id2fgfOzK4qzUeqKkPRvinpQPKK6Tp9ZftIzkIDmByE=
+github.com/hashicorp/vault/sdk v0.9.3-0.20230823221122-925702de10d8/go.mod h1:Dzw6gXoDgUZq2nNhMiuQgw12Pg3+9FQnOWJ67QiGnAo=
 github.com/hashicorp/yamux v0.0.0-20211028200310-0bc27b27de87 h1:xixZ2bWeofWV68J+x6AzmKuVM/JWCQwkWm6GW/MUR6I=
 github.com/hashicorp/yamux v0.0.0-20211028200310-0bc27b27de87/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/passthrough.go
+++ b/passthrough.go
@@ -260,9 +260,7 @@ func (b *PassthroughBackend) handleWrite() framework.OperationFunc {
 			return nil, fmt.Errorf("failed to write: %w", err)
 		}
 
-		kvEvent(ctx, b.Backend, 1, "write",
-			"path", key,
-		)
+		kvEvent(ctx, b.Backend, "write", key, key, 1)
 
 		return nil, nil
 	}
@@ -277,9 +275,7 @@ func (b *PassthroughBackend) handleDelete() framework.OperationFunc {
 			return nil, err
 		}
 
-		kvEvent(ctx, b.Backend, 1, "delete",
-			"path", key,
-		)
+		kvEvent(ctx, b.Backend, "delete", key, key, 1)
 
 		return nil, nil
 	}

--- a/passthrough.go
+++ b/passthrough.go
@@ -260,7 +260,7 @@ func (b *PassthroughBackend) handleWrite() framework.OperationFunc {
 			return nil, fmt.Errorf("failed to write: %w", err)
 		}
 
-		kvEvent(ctx, b.Backend, "write", key, 1)
+		kvEvent(ctx, b.Backend, "write", key, key, true, 1)
 
 		return nil, nil
 	}
@@ -275,7 +275,7 @@ func (b *PassthroughBackend) handleDelete() framework.OperationFunc {
 			return nil, err
 		}
 
-		kvEvent(ctx, b.Backend, "delete", key, 1)
+		kvEvent(ctx, b.Backend, "delete", key, "", true, 1)
 
 		return nil, nil
 	}

--- a/passthrough.go
+++ b/passthrough.go
@@ -260,7 +260,7 @@ func (b *PassthroughBackend) handleWrite() framework.OperationFunc {
 			return nil, fmt.Errorf("failed to write: %w", err)
 		}
 
-		kvEvent(ctx, b.Backend, "write", key, key, 1)
+		kvEvent(ctx, b.Backend, "write", key, 1)
 
 		return nil, nil
 	}
@@ -275,7 +275,7 @@ func (b *PassthroughBackend) handleDelete() framework.OperationFunc {
 			return nil, err
 		}
 
-		kvEvent(ctx, b.Backend, "delete", key, key, 1)
+		kvEvent(ctx, b.Backend, "delete", key, 1)
 
 		return nil, nil
 	}

--- a/passthrough_test.go
+++ b/passthrough_test.go
@@ -205,8 +205,8 @@ func TestPassthroughBackend_Delete(t *testing.T) {
 				true,
 			)
 			events.expectEvents(t, []expectedEvent{
-				{"kv-v1/write", "foo"},
-				{"kv-v1/delete", "foo"},
+				{"kv-v1/write", "foo", "foo"},
+				{"kv-v1/delete", "foo", ""},
 			})
 		})
 	}

--- a/path_config.go
+++ b/path_config.go
@@ -174,7 +174,7 @@ func (b *versionedKVBackend) pathConfigWrite() framework.OperationFunc {
 		defer b.globalConfigLock.Unlock()
 
 		b.globalConfig = config
-		kvEvent(ctx, b.Backend, "config-write", configPath, configPath, 2)
+		kvEvent(ctx, b.Backend, "config-write", configPath, 2)
 		return nil, nil
 	}
 }

--- a/path_config.go
+++ b/path_config.go
@@ -174,8 +174,7 @@ func (b *versionedKVBackend) pathConfigWrite() framework.OperationFunc {
 		defer b.globalConfigLock.Unlock()
 
 		b.globalConfig = config
-		kvEvent(ctx, b.Backend, 2, "config-write",
-			"path", "config")
+		kvEvent(ctx, b.Backend, "config-write", configPath, configPath, 2)
 		return nil, nil
 	}
 }

--- a/path_config.go
+++ b/path_config.go
@@ -174,7 +174,7 @@ func (b *versionedKVBackend) pathConfigWrite() framework.OperationFunc {
 		defer b.globalConfigLock.Unlock()
 
 		b.globalConfig = config
-		kvEvent(ctx, b.Backend, "config-write", configPath, 2)
+		kvEvent(ctx, b.Backend, "config-write", configPath, configPath, true, 2)
 		return nil, nil
 	}
 }

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -71,7 +71,7 @@ func TestVersionedKV_Config(t *testing.T) {
 	}
 
 	events.expectEvents(t, []expectedEvent{
-		{"kv-v2/config-write", "config"},
+		{"kv-v2/config-write", "config", "config"},
 	})
 }
 

--- a/path_data.go
+++ b/path_data.go
@@ -444,7 +444,7 @@ func (b *versionedKVBackend) pathDataWrite() framework.OperationFunc {
 			resp.AddWarning(warning)
 		}
 
-		kvEvent(ctx, b.Backend, "data-write", "data/"+key, 2,
+		kvEvent(ctx, b.Backend, "data-write", "data/"+key, "data/"+key, true, 2,
 			"current_version", fmt.Sprintf("%d", meta.CurrentVersion),
 			"oldest_version", fmt.Sprintf("%d", meta.OldestVersion),
 		)
@@ -643,7 +643,7 @@ func (b *versionedKVBackend) pathDataPatch() framework.OperationFunc {
 			resp.AddWarning(warning)
 		}
 
-		kvEvent(ctx, b.Backend, "data-patch", "data/"+key, 2,
+		kvEvent(ctx, b.Backend, "data-patch", "data/"+key, "data/"+key, true, 2,
 			"current_version", fmt.Sprintf("%d", meta.CurrentVersion),
 			"oldest_version", fmt.Sprintf("%d", meta.OldestVersion),
 		)
@@ -692,7 +692,7 @@ func (b *versionedKVBackend) pathDataDelete() framework.OperationFunc {
 			return nil, err
 		}
 
-		kvEvent(ctx, b.Backend, "data-delete", "data/"+key, 2,
+		kvEvent(ctx, b.Backend, "data-delete", "data/"+key, "", true, 2,
 			"current_version", fmt.Sprintf("%d", meta.CurrentVersion),
 			"oldest_version", fmt.Sprintf("%d", meta.OldestVersion),
 		)

--- a/path_data.go
+++ b/path_data.go
@@ -444,8 +444,7 @@ func (b *versionedKVBackend) pathDataWrite() framework.OperationFunc {
 			resp.AddWarning(warning)
 		}
 
-		kvEvent(ctx, b.Backend, 2, "data-write",
-			"path", "data/"+key,
+		kvEvent(ctx, b.Backend, "data-write", key, "data/"+key, 2,
 			"current_version", fmt.Sprintf("%d", meta.CurrentVersion),
 			"oldest_version", fmt.Sprintf("%d", meta.OldestVersion),
 		)
@@ -644,8 +643,7 @@ func (b *versionedKVBackend) pathDataPatch() framework.OperationFunc {
 			resp.AddWarning(warning)
 		}
 
-		kvEvent(ctx, b.Backend, 2, "data-patch",
-			"path", "data/"+key,
+		kvEvent(ctx, b.Backend, "data-patch", key, "data/"+key, 2,
 			"current_version", fmt.Sprintf("%d", meta.CurrentVersion),
 			"oldest_version", fmt.Sprintf("%d", meta.OldestVersion),
 		)
@@ -694,8 +692,7 @@ func (b *versionedKVBackend) pathDataDelete() framework.OperationFunc {
 			return nil, err
 		}
 
-		kvEvent(ctx, b.Backend, 2, "data-delete",
-			"path", "data/"+key,
+		kvEvent(ctx, b.Backend, "data-delete", key, "data/"+key, 2,
 			"current_version", fmt.Sprintf("%d", meta.CurrentVersion),
 			"oldest_version", fmt.Sprintf("%d", meta.OldestVersion),
 		)

--- a/path_data.go
+++ b/path_data.go
@@ -444,7 +444,7 @@ func (b *versionedKVBackend) pathDataWrite() framework.OperationFunc {
 			resp.AddWarning(warning)
 		}
 
-		kvEvent(ctx, b.Backend, "data-write", key, "data/"+key, 2,
+		kvEvent(ctx, b.Backend, "data-write", "data/"+key, 2,
 			"current_version", fmt.Sprintf("%d", meta.CurrentVersion),
 			"oldest_version", fmt.Sprintf("%d", meta.OldestVersion),
 		)
@@ -643,7 +643,7 @@ func (b *versionedKVBackend) pathDataPatch() framework.OperationFunc {
 			resp.AddWarning(warning)
 		}
 
-		kvEvent(ctx, b.Backend, "data-patch", key, "data/"+key, 2,
+		kvEvent(ctx, b.Backend, "data-patch", "data/"+key, 2,
 			"current_version", fmt.Sprintf("%d", meta.CurrentVersion),
 			"oldest_version", fmt.Sprintf("%d", meta.OldestVersion),
 		)
@@ -692,7 +692,7 @@ func (b *versionedKVBackend) pathDataDelete() framework.OperationFunc {
 			return nil, err
 		}
 
-		kvEvent(ctx, b.Backend, "data-delete", key, "data/"+key, 2,
+		kvEvent(ctx, b.Backend, "data-delete", "data/"+key, 2,
 			"current_version", fmt.Sprintf("%d", meta.CurrentVersion),
 			"oldest_version", fmt.Sprintf("%d", meta.OldestVersion),
 		)

--- a/path_data_test.go
+++ b/path_data_test.go
@@ -182,9 +182,9 @@ func TestVersionedKV_Data_Put(t *testing.T) {
 	}
 
 	events.expectEvents(t, []expectedEvent{
-		{"kv-v2/metadata-write", "metadata/foo"},
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/data-write", "data/foo"},
+		{"kv-v2/metadata-write", "foo"},
+		{"kv-v2/data-write", "foo"},
+		{"kv-v2/data-write", "foo"},
 	})
 }
 
@@ -432,8 +432,8 @@ func TestVersionedKV_Data_Delete(t *testing.T) {
 	}
 
 	events.expectEvents(t, []expectedEvent{
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/data-delete", "data/foo"},
+		{"kv-v2/data-write", "foo"},
+		{"kv-v2/data-delete", "foo"},
 	})
 }
 
@@ -1055,9 +1055,9 @@ func TestVersionedKV_Patch_Success(t *testing.T) {
 	}
 
 	events.expectEvents(t, []expectedEvent{
-		{"kv-v2/metadata-write", "metadata/foo"},
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/data-patch", "data/foo"},
+		{"kv-v2/metadata-write", "foo"},
+		{"kv-v2/data-write", "foo"},
+		{"kv-v2/data-patch", "foo"},
 	})
 }
 

--- a/path_data_test.go
+++ b/path_data_test.go
@@ -182,9 +182,9 @@ func TestVersionedKV_Data_Put(t *testing.T) {
 	}
 
 	events.expectEvents(t, []expectedEvent{
-		{"kv-v2/metadata-write", "metadata/foo"},
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/data-write", "data/foo"},
+		{"kv-v2/metadata-write", "metadata/foo", "metadata/foo"},
+		{"kv-v2/data-write", "data/foo", "data/foo"},
+		{"kv-v2/data-write", "data/foo", "data/foo"},
 	})
 }
 
@@ -432,8 +432,8 @@ func TestVersionedKV_Data_Delete(t *testing.T) {
 	}
 
 	events.expectEvents(t, []expectedEvent{
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/data-delete", "data/foo"},
+		{"kv-v2/data-write", "data/foo", "data/foo"},
+		{"kv-v2/data-delete", "data/foo", ""},
 	})
 }
 
@@ -1055,9 +1055,9 @@ func TestVersionedKV_Patch_Success(t *testing.T) {
 	}
 
 	events.expectEvents(t, []expectedEvent{
-		{"kv-v2/metadata-write", "metadata/foo"},
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/data-patch", "data/foo"},
+		{"kv-v2/metadata-write", "metadata/foo", "metadata/foo"},
+		{"kv-v2/data-write", "data/foo", "data/foo"},
+		{"kv-v2/data-patch", "data/foo", "data/foo"},
 	})
 }
 

--- a/path_data_test.go
+++ b/path_data_test.go
@@ -182,9 +182,9 @@ func TestVersionedKV_Data_Put(t *testing.T) {
 	}
 
 	events.expectEvents(t, []expectedEvent{
-		{"kv-v2/metadata-write", "foo"},
-		{"kv-v2/data-write", "foo"},
-		{"kv-v2/data-write", "foo"},
+		{"kv-v2/metadata-write", "metadata/foo"},
+		{"kv-v2/data-write", "data/foo"},
+		{"kv-v2/data-write", "data/foo"},
 	})
 }
 
@@ -432,8 +432,8 @@ func TestVersionedKV_Data_Delete(t *testing.T) {
 	}
 
 	events.expectEvents(t, []expectedEvent{
-		{"kv-v2/data-write", "foo"},
-		{"kv-v2/data-delete", "foo"},
+		{"kv-v2/data-write", "data/foo"},
+		{"kv-v2/data-delete", "data/foo"},
 	})
 }
 
@@ -1055,9 +1055,9 @@ func TestVersionedKV_Patch_Success(t *testing.T) {
 	}
 
 	events.expectEvents(t, []expectedEvent{
-		{"kv-v2/metadata-write", "foo"},
-		{"kv-v2/data-write", "foo"},
-		{"kv-v2/data-patch", "foo"},
+		{"kv-v2/metadata-write", "metadata/foo"},
+		{"kv-v2/data-write", "data/foo"},
+		{"kv-v2/data-patch", "data/foo"},
 	})
 }
 

--- a/path_delete.go
+++ b/path_delete.go
@@ -143,8 +143,7 @@ func (b *versionedKVBackend) pathUndeleteWrite() framework.OperationFunc {
 		if err != nil {
 			return nil, err
 		}
-		kvEvent(ctx, b.Backend, 2, "undelete",
-			"path", "undelete/"+key,
+		kvEvent(ctx, b.Backend, "undelete", key, "data/"+key, 2,
 			"current_version", fmt.Sprintf("%d", meta.CurrentVersion),
 			"oldest_version", fmt.Sprintf("%d", meta.OldestVersion),
 			"undeleted_versions", string(marshaledVersions),
@@ -205,8 +204,7 @@ func (b *versionedKVBackend) pathDeleteWrite() framework.OperationFunc {
 		if err != nil {
 			return nil, err
 		}
-		kvEvent(ctx, b.Backend, 2, "delete",
-			"path", "delete/"+key,
+		kvEvent(ctx, b.Backend, "delete", key, "data/"+key, 2,
 			"current_version", fmt.Sprintf("%d", meta.CurrentVersion),
 			"oldest_version", fmt.Sprintf("%d", meta.OldestVersion),
 			"deleted_versions", string(marshaledVersions),

--- a/path_delete.go
+++ b/path_delete.go
@@ -143,7 +143,7 @@ func (b *versionedKVBackend) pathUndeleteWrite() framework.OperationFunc {
 		if err != nil {
 			return nil, err
 		}
-		kvEvent(ctx, b.Backend, "undelete", "data/"+key, 2,
+		kvEvent(ctx, b.Backend, "undelete", "undelete/"+key, "data/"+key, true, 2,
 			"current_version", fmt.Sprintf("%d", meta.CurrentVersion),
 			"oldest_version", fmt.Sprintf("%d", meta.OldestVersion),
 			"undeleted_versions", string(marshaledVersions),
@@ -204,7 +204,7 @@ func (b *versionedKVBackend) pathDeleteWrite() framework.OperationFunc {
 		if err != nil {
 			return nil, err
 		}
-		kvEvent(ctx, b.Backend, "delete", "data/"+key, 2,
+		kvEvent(ctx, b.Backend, "delete", "delete/"+key, "", true, 2,
 			"current_version", fmt.Sprintf("%d", meta.CurrentVersion),
 			"oldest_version", fmt.Sprintf("%d", meta.OldestVersion),
 			"deleted_versions", string(marshaledVersions),

--- a/path_delete.go
+++ b/path_delete.go
@@ -143,7 +143,7 @@ func (b *versionedKVBackend) pathUndeleteWrite() framework.OperationFunc {
 		if err != nil {
 			return nil, err
 		}
-		kvEvent(ctx, b.Backend, "undelete", key, "data/"+key, 2,
+		kvEvent(ctx, b.Backend, "undelete", "data/"+key, 2,
 			"current_version", fmt.Sprintf("%d", meta.CurrentVersion),
 			"oldest_version", fmt.Sprintf("%d", meta.OldestVersion),
 			"undeleted_versions", string(marshaledVersions),
@@ -204,7 +204,7 @@ func (b *versionedKVBackend) pathDeleteWrite() framework.OperationFunc {
 		if err != nil {
 			return nil, err
 		}
-		kvEvent(ctx, b.Backend, "delete", key, "data/"+key, 2,
+		kvEvent(ctx, b.Backend, "delete", "data/"+key, 2,
 			"current_version", fmt.Sprintf("%d", meta.CurrentVersion),
 			"oldest_version", fmt.Sprintf("%d", meta.OldestVersion),
 			"deleted_versions", string(marshaledVersions),

--- a/path_delete_test.go
+++ b/path_delete_test.go
@@ -115,9 +115,9 @@ func TestVersionedKV_Delete_Put(t *testing.T) {
 	}
 
 	events.expectEvents(t, []expectedEvent{
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/delete", "delete/foo"},
+		{"kv-v2/data-write", "foo"},
+		{"kv-v2/data-write", "foo"},
+		{"kv-v2/delete", "foo"},
 	})
 }
 
@@ -235,9 +235,9 @@ func TestVersionedKV_Undelete_Put(t *testing.T) {
 	}
 
 	events.expectEvents(t, []expectedEvent{
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/delete", "delete/foo"},
-		{"kv-v2/undelete", "undelete/foo"},
+		{"kv-v2/data-write", "foo"},
+		{"kv-v2/data-write", "foo"},
+		{"kv-v2/delete", "foo"},
+		{"kv-v2/undelete", "foo"},
 	})
 }

--- a/path_delete_test.go
+++ b/path_delete_test.go
@@ -115,9 +115,9 @@ func TestVersionedKV_Delete_Put(t *testing.T) {
 	}
 
 	events.expectEvents(t, []expectedEvent{
-		{"kv-v2/data-write", "foo"},
-		{"kv-v2/data-write", "foo"},
-		{"kv-v2/delete", "foo"},
+		{"kv-v2/data-write", "data/foo"},
+		{"kv-v2/data-write", "data/foo"},
+		{"kv-v2/delete", "data/foo"},
 	})
 }
 
@@ -235,9 +235,9 @@ func TestVersionedKV_Undelete_Put(t *testing.T) {
 	}
 
 	events.expectEvents(t, []expectedEvent{
-		{"kv-v2/data-write", "foo"},
-		{"kv-v2/data-write", "foo"},
-		{"kv-v2/delete", "foo"},
-		{"kv-v2/undelete", "foo"},
+		{"kv-v2/data-write", "data/foo"},
+		{"kv-v2/data-write", "data/foo"},
+		{"kv-v2/delete", "data/foo"},
+		{"kv-v2/undelete", "data/foo"},
 	})
 }

--- a/path_delete_test.go
+++ b/path_delete_test.go
@@ -115,9 +115,9 @@ func TestVersionedKV_Delete_Put(t *testing.T) {
 	}
 
 	events.expectEvents(t, []expectedEvent{
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/delete", "data/foo"},
+		{"kv-v2/data-write", "data/foo", "data/foo"},
+		{"kv-v2/data-write", "data/foo", "data/foo"},
+		{"kv-v2/delete", "delete/foo", ""},
 	})
 }
 
@@ -235,9 +235,9 @@ func TestVersionedKV_Undelete_Put(t *testing.T) {
 	}
 
 	events.expectEvents(t, []expectedEvent{
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/delete", "data/foo"},
-		{"kv-v2/undelete", "data/foo"},
+		{"kv-v2/data-write", "data/foo", "data/foo"},
+		{"kv-v2/data-write", "data/foo", "data/foo"},
+		{"kv-v2/delete", "delete/foo", ""},
+		{"kv-v2/undelete", "undelete/foo", "data/foo"},
 	})
 }

--- a/path_destroy.go
+++ b/path_destroy.go
@@ -100,7 +100,7 @@ func (b *versionedKVBackend) pathDestroyWrite() framework.OperationFunc {
 				return nil, err
 			}
 		}
-		kvEvent(ctx, b.Backend, "destroy", "data/"+key, 2,
+		kvEvent(ctx, b.Backend, "destroy", "destroy/"+key, "", true, 2,
 			"current_version", fmt.Sprintf("%d", meta.CurrentVersion),
 			"oldest_version", fmt.Sprintf("%d", meta.OldestVersion),
 		)

--- a/path_destroy.go
+++ b/path_destroy.go
@@ -100,8 +100,7 @@ func (b *versionedKVBackend) pathDestroyWrite() framework.OperationFunc {
 				return nil, err
 			}
 		}
-		kvEvent(ctx, b.Backend, 2, "destroy",
-			"path", "destroy/"+key,
+		kvEvent(ctx, b.Backend, "destroy", key, "data/"+key, 2,
 			"current_version", fmt.Sprintf("%d", meta.CurrentVersion),
 			"oldest_version", fmt.Sprintf("%d", meta.OldestVersion),
 		)

--- a/path_destroy.go
+++ b/path_destroy.go
@@ -100,7 +100,7 @@ func (b *versionedKVBackend) pathDestroyWrite() framework.OperationFunc {
 				return nil, err
 			}
 		}
-		kvEvent(ctx, b.Backend, "destroy", key, "data/"+key, 2,
+		kvEvent(ctx, b.Backend, "destroy", "data/"+key, 2,
 			"current_version", fmt.Sprintf("%d", meta.CurrentVersion),
 			"oldest_version", fmt.Sprintf("%d", meta.OldestVersion),
 		)

--- a/path_destroy_test.go
+++ b/path_destroy_test.go
@@ -103,8 +103,8 @@ func TestVersionedKV_Destroy_Put(t *testing.T) {
 	}
 
 	events.expectEvents(t, []expectedEvent{
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/destroy", "destroy/foo"},
+		{"kv-v2/data-write", "foo"},
+		{"kv-v2/data-write", "foo"},
+		{"kv-v2/destroy", "foo"},
 	})
 }

--- a/path_destroy_test.go
+++ b/path_destroy_test.go
@@ -103,8 +103,8 @@ func TestVersionedKV_Destroy_Put(t *testing.T) {
 	}
 
 	events.expectEvents(t, []expectedEvent{
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/destroy", "data/foo"},
+		{"kv-v2/data-write", "data/foo", "data/foo"},
+		{"kv-v2/data-write", "data/foo", "data/foo"},
+		{"kv-v2/destroy", "destroy/foo", ""},
 	})
 }

--- a/path_destroy_test.go
+++ b/path_destroy_test.go
@@ -103,8 +103,8 @@ func TestVersionedKV_Destroy_Put(t *testing.T) {
 	}
 
 	events.expectEvents(t, []expectedEvent{
-		{"kv-v2/data-write", "foo"},
-		{"kv-v2/data-write", "foo"},
-		{"kv-v2/destroy", "foo"},
+		{"kv-v2/data-write", "data/foo"},
+		{"kv-v2/data-write", "data/foo"},
+		{"kv-v2/destroy", "data/foo"},
 	})
 }

--- a/path_metadata.go
+++ b/path_metadata.go
@@ -416,7 +416,7 @@ func (b *versionedKVBackend) pathMetadataWrite() framework.OperationFunc {
 		}
 
 		err = b.writeKeyMetadata(ctx, req.Storage, meta)
-		kvEvent(ctx, b.Backend, "metadata-write", key, "metadata/"+key, 2)
+		kvEvent(ctx, b.Backend, "metadata-write", "metadata/"+key, 2)
 		return resp, err
 	}
 }
@@ -529,7 +529,7 @@ func (b *versionedKVBackend) pathMetadataPatch() framework.OperationFunc {
 			return nil, err
 		}
 
-		kvEvent(ctx, b.Backend, "metadata-patch", key, "metadata/"+key, 2)
+		kvEvent(ctx, b.Backend, "metadata-patch", "metadata/"+key, 2)
 		return resp, nil
 	}
 }
@@ -573,7 +573,7 @@ func (b *versionedKVBackend) pathMetadataDelete() framework.OperationFunc {
 
 		// Use encrypted key storage to delete the key
 		err = es.Delete(ctx, key)
-		kvEvent(ctx, b.Backend, "metadata-delete", key, "metadata/"+key, 2)
+		kvEvent(ctx, b.Backend, "metadata-delete", "metadata/"+key, 2)
 		return nil, err
 	}
 }

--- a/path_metadata.go
+++ b/path_metadata.go
@@ -416,7 +416,7 @@ func (b *versionedKVBackend) pathMetadataWrite() framework.OperationFunc {
 		}
 
 		err = b.writeKeyMetadata(ctx, req.Storage, meta)
-		kvEvent(ctx, b.Backend, "metadata-write", "metadata/"+key, 2)
+		kvEvent(ctx, b.Backend, "metadata-write", "metadata/"+key, "metadata/"+key, true, 2)
 		return resp, err
 	}
 }
@@ -529,7 +529,7 @@ func (b *versionedKVBackend) pathMetadataPatch() framework.OperationFunc {
 			return nil, err
 		}
 
-		kvEvent(ctx, b.Backend, "metadata-patch", "metadata/"+key, 2)
+		kvEvent(ctx, b.Backend, "metadata-patch", "metadata/"+key, "metadata/"+key, true, 2)
 		return resp, nil
 	}
 }
@@ -573,7 +573,7 @@ func (b *versionedKVBackend) pathMetadataDelete() framework.OperationFunc {
 
 		// Use encrypted key storage to delete the key
 		err = es.Delete(ctx, key)
-		kvEvent(ctx, b.Backend, "metadata-delete", "metadata/"+key, 2)
+		kvEvent(ctx, b.Backend, "metadata-delete", "metadata/"+key, "", true, 2)
 		return nil, err
 	}
 }

--- a/path_metadata.go
+++ b/path_metadata.go
@@ -416,9 +416,7 @@ func (b *versionedKVBackend) pathMetadataWrite() framework.OperationFunc {
 		}
 
 		err = b.writeKeyMetadata(ctx, req.Storage, meta)
-		kvEvent(ctx, b.Backend, 2, "metadata-write",
-			"path", "metadata/"+key,
-		)
+		kvEvent(ctx, b.Backend, "metadata-write", key, "metadata/"+key, 2)
 		return resp, err
 	}
 }
@@ -531,9 +529,7 @@ func (b *versionedKVBackend) pathMetadataPatch() framework.OperationFunc {
 			return nil, err
 		}
 
-		kvEvent(ctx, b.Backend, 2, "metadata-patch",
-			"path", "metadata/"+key,
-		)
+		kvEvent(ctx, b.Backend, "metadata-patch", key, "metadata/"+key, 2)
 		return resp, nil
 	}
 }
@@ -577,9 +573,7 @@ func (b *versionedKVBackend) pathMetadataDelete() framework.OperationFunc {
 
 		// Use encrypted key storage to delete the key
 		err = es.Delete(ctx, key)
-		kvEvent(ctx, b.Backend, 2, "metadata-delete",
-			"path", "metadata/"+key,
-		)
+		kvEvent(ctx, b.Backend, "metadata-delete", key, "metadata/"+key, 2)
 		return nil, err
 	}
 }

--- a/path_metadata_test.go
+++ b/path_metadata_test.go
@@ -385,13 +385,13 @@ func TestVersionedKV_Metadata_Delete(t *testing.T) {
 	}
 
 	events.expectEvents(t, []expectedEvent{
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/metadata-delete", "metadata/foo"},
+		{"kv-v2/data-write", "foo"},
+		{"kv-v2/data-write", "foo"},
+		{"kv-v2/data-write", "foo"},
+		{"kv-v2/data-write", "foo"},
+		{"kv-v2/data-write", "foo"},
+		{"kv-v2/data-write", "foo"},
+		{"kv-v2/metadata-delete", "foo"},
 	})
 }
 
@@ -1462,8 +1462,8 @@ func TestVersionedKV_Metadata_Patch_Success(t *testing.T) {
 			}
 
 			events.expectEvents(t, []expectedEvent{
-				{"kv-v2/metadata-write", path},
-				{"kv-v2/metadata-patch", path},
+				{"kv-v2/metadata-write", strings.TrimPrefix(path, "metadata/")},
+				{"kv-v2/metadata-patch", strings.TrimPrefix(path, "metadata/")},
 			})
 		})
 	}

--- a/path_metadata_test.go
+++ b/path_metadata_test.go
@@ -385,13 +385,13 @@ func TestVersionedKV_Metadata_Delete(t *testing.T) {
 	}
 
 	events.expectEvents(t, []expectedEvent{
-		{"kv-v2/data-write", "foo"},
-		{"kv-v2/data-write", "foo"},
-		{"kv-v2/data-write", "foo"},
-		{"kv-v2/data-write", "foo"},
-		{"kv-v2/data-write", "foo"},
-		{"kv-v2/data-write", "foo"},
-		{"kv-v2/metadata-delete", "foo"},
+		{"kv-v2/data-write", "data/foo"},
+		{"kv-v2/data-write", "data/foo"},
+		{"kv-v2/data-write", "data/foo"},
+		{"kv-v2/data-write", "data/foo"},
+		{"kv-v2/data-write", "data/foo"},
+		{"kv-v2/data-write", "data/foo"},
+		{"kv-v2/metadata-delete", "metadata/foo"},
 	})
 }
 
@@ -1462,8 +1462,8 @@ func TestVersionedKV_Metadata_Patch_Success(t *testing.T) {
 			}
 
 			events.expectEvents(t, []expectedEvent{
-				{"kv-v2/metadata-write", strings.TrimPrefix(path, "metadata/")},
-				{"kv-v2/metadata-patch", strings.TrimPrefix(path, "metadata/")},
+				{"kv-v2/metadata-write", path},
+				{"kv-v2/metadata-patch", path},
 			})
 		})
 	}

--- a/path_metadata_test.go
+++ b/path_metadata_test.go
@@ -385,13 +385,13 @@ func TestVersionedKV_Metadata_Delete(t *testing.T) {
 	}
 
 	events.expectEvents(t, []expectedEvent{
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/data-write", "data/foo"},
-		{"kv-v2/metadata-delete", "metadata/foo"},
+		{"kv-v2/data-write", "data/foo", "data/foo"},
+		{"kv-v2/data-write", "data/foo", "data/foo"},
+		{"kv-v2/data-write", "data/foo", "data/foo"},
+		{"kv-v2/data-write", "data/foo", "data/foo"},
+		{"kv-v2/data-write", "data/foo", "data/foo"},
+		{"kv-v2/data-write", "data/foo", "data/foo"},
+		{"kv-v2/metadata-delete", "metadata/foo", ""},
 	})
 }
 
@@ -1462,8 +1462,8 @@ func TestVersionedKV_Metadata_Patch_Success(t *testing.T) {
 			}
 
 			events.expectEvents(t, []expectedEvent{
-				{"kv-v2/metadata-write", path},
-				{"kv-v2/metadata-patch", path},
+				{"kv-v2/metadata-write", path, path},
+				{"kv-v2/metadata-patch", path, path},
 			})
 		})
 	}


### PR DESCRIPTION
This preserves the existing `path` entry in the metadata for backwards compatibility.

The `api_path` is the path to the secret in Vault.

The `operation` is what operation is being performed, which may be plugin-dependent.

This depends on https://github.com/hashicorp/vault/pull/22487 being merged and bumped in `go.mod` before this will compile (since it references new constants and a function in the SDK, though this could be removed).
