### PR TITLE
fix: empty lines after return

### DIFF
--- a/path_data.go
+++ b/path_data.go
@@ -220,14 +220,12 @@ func (b *versionedKVBackend) pathDataRead() framework.OperationFunc {
 
 			if deletionTime.Before(time.Now()) {
 				return logical.RespondWithStatusCode(resp, req, http.StatusNotFound)
-
 			}
 		}
 
 		// If the version has been destroyed return metadata with a 404
 		if vm.Destroyed {
 			return logical.RespondWithStatusCode(resp, req, http.StatusNotFound)
-
 		}
 
 		versionKey, err := b.getVersionKey(ctx, key, verNum, req.Storage)


### PR DESCRIPTION
# Overview

Fixes redundant empty newlines after return statements 