### PR TITLE
Add ecosystem to codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in
 # the repo, unless a later match takes precedence.
 
-* @hashicorp/vault-core
+* @hashicorp/vault-core @hashicorp/vault-ecosystem


### PR DESCRIPTION
# Overview
Adding ecosystem to codeowners for plugin releasing purposes. Ecosystem does the plugin releases for this repository and needs to be able to approve PRs.

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible
