### PR TITLE
Add extra version information for KV observations

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -454,7 +454,6 @@ func recordKvObservation(ctx context.Context, b *framework.Backend, req *logical
 		"client_id":  req.ClientID,
 		"entity_id":  req.EntityID,
 		"request_id": req.ID,
-		"modified":   kvObservationIsWrite(observationType),
 	}
 	for _, meta := range additionalMetadata {
 		metadata[meta.key] = meta.value

--- a/backend.go
+++ b/backend.go
@@ -462,8 +462,8 @@ func recordKvObservation(ctx context.Context, b *framework.Backend, req *logical
 
 	err := b.RecordObservation(ctx, observationType, metadata)
 
-	if err != nil && errors.Is(err, framework.ErrNoObservations) {
-		b.Logger().Error("Error recording observation", "observationType", observationType, "error", err)
+	if err != nil && !errors.Is(err, framework.ErrNoObservations) {
+		b.Logger().Error("error recording observation", "observationType", observationType, "error", err)
 	}
 }
 

--- a/path_data.go
+++ b/path_data.go
@@ -449,7 +449,10 @@ func (b *versionedKVBackend) pathDataWrite() framework.OperationFunc {
 			"current_version", fmt.Sprintf("%d", meta.CurrentVersion),
 			"oldest_version", fmt.Sprintf("%d", meta.OldestVersion),
 		)
-		recordKvObservation(ctx, b.Backend, req, ObservationTypeKVv2SecretWrite)
+		recordKvObservation(ctx, b.Backend, req, ObservationTypeKVv2SecretWrite,
+			AdditionalKVMetadata{key: "is_new_secret", value: meta.CurrentVersion == 1 && meta.OldestVersion == 1},
+			AdditionalKVMetadata{key: "oldest_version", value: meta.OldestVersion},
+			AdditionalKVMetadata{key: "current_version", value: meta.CurrentVersion})
 
 		return resp, nil
 	}
@@ -650,7 +653,9 @@ func (b *versionedKVBackend) pathDataPatch() framework.OperationFunc {
 			"current_version", fmt.Sprintf("%d", meta.CurrentVersion),
 			"oldest_version", fmt.Sprintf("%d", meta.OldestVersion),
 		)
-		recordKvObservation(ctx, b.Backend, req, ObservationTypeKVv2SecretPatch)
+		recordKvObservation(ctx, b.Backend, req, ObservationTypeKVv2SecretPatch,
+			AdditionalKVMetadata{key: "oldest_version", value: meta.OldestVersion},
+			AdditionalKVMetadata{key: "current_version", value: meta.CurrentVersion})
 		return resp, nil
 	}
 }

--- a/path_delete.go
+++ b/path_delete.go
@@ -149,6 +149,8 @@ func (b *versionedKVBackend) pathUndeleteWrite() framework.OperationFunc {
 			"undeleted_versions", string(marshaledVersions),
 		)
 		recordKvObservation(ctx, b.Backend, req, ObservationTypeKVv2SecretUndelete,
+			AdditionalKVMetadata{key: "oldest_version", value: meta.OldestVersion},
+			AdditionalKVMetadata{key: "current_version", value: meta.CurrentVersion},
 			AdditionalKVMetadata{key: "undeleted_versions", value: marshaledVersions})
 		return nil, nil
 	}
@@ -212,6 +214,7 @@ func (b *versionedKVBackend) pathDeleteWrite() framework.OperationFunc {
 			"deleted_versions", string(marshaledVersions),
 		)
 		recordKvObservation(ctx, b.Backend, req, ObservationTypeKVv2SecretDelete,
+			AdditionalKVMetadata{key: "current_version", value: meta.CurrentVersion},
 			AdditionalKVMetadata{key: "deleted_versions", value: marshaledVersions})
 		return nil, nil
 	}

--- a/path_destroy.go
+++ b/path_destroy.go
@@ -111,6 +111,8 @@ func (b *versionedKVBackend) pathDestroyWrite() framework.OperationFunc {
 			"destroyed_versions", string(marshaledVersions),
 		)
 		recordKvObservation(ctx, b.Backend, req, ObservationTypeKVv2SecretDestroy,
+			AdditionalKVMetadata{key: "current_version", value: meta.CurrentVersion},
+			AdditionalKVMetadata{key: "oldest_version", value: meta.OldestVersion},
 			AdditionalKVMetadata{key: "destroyed_versions", value: marshaledVersions})
 		return nil, nil
 	}


### PR DESCRIPTION
# Overview

Some extra version information for KV observations, and a minor bug fix for error logging.

# Design of Change
How was this change implemented?

# Related Issues/Pull Requests
[ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)
[ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible
