### PR TITLE
Allow listing only non-deleted kv secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+CHANGES:
+
+* Add support for listing only non-deleted KV entries [GH-196](https://github.com/hashicorp/vault-plugin-secrets-kv/pull/196)
+
+
 ## v0.24.0
 
 CHANGES:


### PR DESCRIPTION
# Overview

This allows listing Vault KV secrets while filtering out deleted entries. The default behavior of listing secrets hasn't changed, but a new boolean parameter named `exclude_deleted` is added, that defaults to false.
When this boolean is set to true,  secrets where the current version is deleted will be filtered out from the `list` output.

## Motivation

Currently, when looping through Vault secrets from remote locations (e.g., Australia), the process can be slow because soft-deleted secrets appear in the secret list operations and require additional metadata checks to determine their status.  This creates an incentive for users to perform destructive metadata deletions just to clean up listings, even when there's a good case for keeping deleted secrets around for potential rollback scenarios.


This change allows users to exclude soft deleted entries when listing secrets to speed up Vault searches and avoid having to destroy data unnecessarily


## Changes

- Added optional `exclude_deleted` boolean parameter to metadata list operations
- When `exclude_deleted=true`, filters out keys where the current version has been soft-deleted
- Backward compatibility: default behavior unchanged
- Only checks current version deletion status (not historical versions)

If this change is accepted, I can update the documentation on `hashicorp/vault` side as well.

I'm not super familiar with Golang, so please let me know if anything needs to be modified / can be improved ☺️

# Related Issues/Pull Requests
Solves: https://github.com/hashicorp/vault/issues/8432#issuecomment-1979747487

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible

# PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
