### PR TITLE
VAULT-38794 versions on KV observations

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"path"
+	"slices"
 	"strconv"
 	"sync"
 
@@ -445,6 +447,15 @@ func kvObservationIsWrite(observationType string) bool {
 type AdditionalKVMetadata struct {
 	key   string
 	value interface{}
+}
+
+// kvVersionsMapToSlice is intended to take meta.Versions and return a readable slice
+// of versions. Note that this is UNSORTED, so could return e.g.:
+// [1]
+// [1,2,3]
+// [2,3,1]
+func kvVersionsMapToSlice(versions map[uint64]*VersionMetadata) []uint64 {
+	return slices.Collect(maps.Keys(versions))
 }
 
 func recordKvObservation(ctx context.Context, b *framework.Backend, req *logical.Request, observationType string,

--- a/path_data.go
+++ b/path_data.go
@@ -452,6 +452,7 @@ func (b *versionedKVBackend) pathDataWrite() framework.OperationFunc {
 		recordKvObservation(ctx, b.Backend, req, ObservationTypeKVv2SecretWrite,
 			AdditionalKVMetadata{key: "is_new_secret", value: meta.CurrentVersion == 1 && meta.OldestVersion == 1},
 			AdditionalKVMetadata{key: "oldest_version", value: meta.OldestVersion},
+			AdditionalKVMetadata{key: "versions", value: kvVersionsMapToSlice(meta.Versions)},
 			AdditionalKVMetadata{key: "current_version", value: meta.CurrentVersion})
 
 		return resp, nil
@@ -655,6 +656,7 @@ func (b *versionedKVBackend) pathDataPatch() framework.OperationFunc {
 		)
 		recordKvObservation(ctx, b.Backend, req, ObservationTypeKVv2SecretPatch,
 			AdditionalKVMetadata{key: "oldest_version", value: meta.OldestVersion},
+			AdditionalKVMetadata{key: "versions", value: kvVersionsMapToSlice(meta.Versions)},
 			AdditionalKVMetadata{key: "current_version", value: meta.CurrentVersion})
 		return resp, nil
 	}
@@ -705,7 +707,9 @@ func (b *versionedKVBackend) pathDataDelete() framework.OperationFunc {
 			"current_version", fmt.Sprintf("%d", meta.CurrentVersion),
 			"oldest_version", fmt.Sprintf("%d", meta.OldestVersion),
 		)
-		recordKvObservation(ctx, b.Backend, req, ObservationTypeKVv2SecretDelete)
+		recordKvObservation(ctx, b.Backend, req, ObservationTypeKVv2SecretDelete,
+			AdditionalKVMetadata{key: "current_version", value: meta.CurrentVersion},
+			AdditionalKVMetadata{key: "versions", value: kvVersionsMapToSlice(meta.Versions)})
 		return nil, nil
 	}
 }

--- a/path_delete.go
+++ b/path_delete.go
@@ -151,6 +151,7 @@ func (b *versionedKVBackend) pathUndeleteWrite() framework.OperationFunc {
 		recordKvObservation(ctx, b.Backend, req, ObservationTypeKVv2SecretUndelete,
 			AdditionalKVMetadata{key: "oldest_version", value: meta.OldestVersion},
 			AdditionalKVMetadata{key: "current_version", value: meta.CurrentVersion},
+			AdditionalKVMetadata{key: "versions", value: kvVersionsMapToSlice(meta.Versions)},
 			AdditionalKVMetadata{key: "undeleted_versions", value: marshaledVersions})
 		return nil, nil
 	}
@@ -215,6 +216,7 @@ func (b *versionedKVBackend) pathDeleteWrite() framework.OperationFunc {
 		)
 		recordKvObservation(ctx, b.Backend, req, ObservationTypeKVv2SecretDelete,
 			AdditionalKVMetadata{key: "current_version", value: meta.CurrentVersion},
+			AdditionalKVMetadata{key: "versions", value: kvVersionsMapToSlice(meta.Versions)},
 			AdditionalKVMetadata{key: "deleted_versions", value: marshaledVersions})
 		return nil, nil
 	}

--- a/path_destroy.go
+++ b/path_destroy.go
@@ -7,11 +7,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
-
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/locksutil"
 	"github.com/hashicorp/vault/sdk/logical"
+	"net/http"
 )
 
 // pathDestroy returns the path configuration for the destroy endpoint
@@ -113,6 +112,7 @@ func (b *versionedKVBackend) pathDestroyWrite() framework.OperationFunc {
 		recordKvObservation(ctx, b.Backend, req, ObservationTypeKVv2SecretDestroy,
 			AdditionalKVMetadata{key: "current_version", value: meta.CurrentVersion},
 			AdditionalKVMetadata{key: "oldest_version", value: meta.OldestVersion},
+			AdditionalKVMetadata{key: "versions", value: kvVersionsMapToSlice(meta.Versions)},
 			AdditionalKVMetadata{key: "destroyed_versions", value: marshaledVersions})
 		return nil, nil
 	}


### PR DESCRIPTION
# Overview

This adds an array of versions to all 'write' observations to support the requirements of the Reporting project.

# Design of Change
How was this change implemented?

# Related Issues/Pull Requests
[ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)
[ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible

# PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
