### PR TITLE
Add oldest_version to kvv2 delete observations

### DIFF
--- a/path_data.go
+++ b/path_data.go
@@ -708,6 +708,7 @@ func (b *versionedKVBackend) pathDataDelete() framework.OperationFunc {
 			"oldest_version", fmt.Sprintf("%d", meta.OldestVersion),
 		)
 		recordKvObservation(ctx, b.Backend, req, ObservationTypeKVv2SecretDelete,
+			AdditionalKVMetadata{key: "oldest_version", value: meta.OldestVersion},
 			AdditionalKVMetadata{key: "current_version", value: meta.CurrentVersion},
 			AdditionalKVMetadata{key: "versions", value: kvVersionsMapToSlice(meta.Versions)})
 		return nil, nil


### PR DESCRIPTION
# Overview

For reporting initiative.

oldest_version is present on all other 'write' style observations, it was just missed from this one.

# Design of Change
How was this change implemented?

# Related Issues/Pull Requests
[ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)
[ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible

# PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
