### PR TITLE
Kv version attr

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -515,15 +515,16 @@ func ptypesTimestampToString(t *timestamp.Timestamp) string {
 
 func getAttribution(req *logical.Request) *Attribution {
 	// Get actor
-	actor := req.DisplayName
-	if actor == "" {
-		// Set actor to the client ID if no display name is present
-		actor = req.ClientID
+	clientID := req.ClientID
+	if req.EntityID != "" {
+		// Don't show duplicate EntityID if it's already set.
+		clientID = ""
 	}
 
 	attr := &Attribution{
-		Actor:     actor,
+		Actor:     req.DisplayName,
 		EntityId:  req.EntityID,
+		ClientId:  req.ClientID,
 		Operation: string(req.Operation),
 	}
 

--- a/backend.go
+++ b/backend.go
@@ -198,7 +198,7 @@ func pathInvalid(b *versionedKVBackend) []*framework.Path {
 	}
 
 	return []*framework.Path{
-		&framework.Path{
+		{
 			Pattern: ".*",
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.UpdateOperation: &framework.PathOperation{Callback: handler, Unpublished: true},
@@ -385,7 +385,6 @@ func (b *versionedKVBackend) getVersionKey(ctx context.Context, key string, vers
 // getKeyMetadata returns the metadata object for the provided key, if no object
 // exits it will return nil.
 func (b *versionedKVBackend) getKeyMetadata(ctx context.Context, s logical.Storage, key string) (*KeyMetadata, error) {
-
 	wrapper, err := b.getKeyEncryptor(ctx, s)
 	if err != nil {
 		return nil, err
@@ -459,7 +458,8 @@ func kvVersionsMapToSlice(versions map[uint64]*VersionMetadata) []uint64 {
 }
 
 func recordKvObservation(ctx context.Context, b *framework.Backend, req *logical.Request, observationType string,
-	additionalMetadata ...AdditionalKVMetadata) {
+	additionalMetadata ...AdditionalKVMetadata,
+) {
 	metadata := map[string]interface{}{
 		"path":       req.Path,
 		"client_id":  req.ClientID,
@@ -488,8 +488,8 @@ func kvEvent(ctx context.Context,
 	dataPath string,
 	modified bool,
 	kvVersion int,
-	additionalMetadataPairs ...string) {
-
+	additionalMetadataPairs ...string,
+) {
 	metadata := []string{
 		logical.EventMetadataModified, strconv.FormatBool(modified),
 		logical.EventMetadataOperation, operation,
@@ -513,7 +513,7 @@ func ptypesTimestampToString(t *timestamp.Timestamp) string {
 	return ptypes.TimestampString(t)
 }
 
-func getAttributionFromRequest(req *logical.Request) *Attribution {
+func getAttribution(req *logical.Request) *Attribution {
 	// Get actor
 	actor := req.DisplayName
 	if actor == "" {

--- a/upgrade.go
+++ b/upgrade.go
@@ -189,14 +189,14 @@ func (b *versionedKVBackend) Upgrade(ctx context.Context, s logical.Storage) err
 		}
 
 		// Create attribution
-		attribution := &Attribution{
+		meta.LastUpdatedBy = &Attribution{
 			Actor:     "kv_upgrade",
 			Operation: "upgrade",
 			EntityId:  "",
 		}
 
 		// Store the metadata
-		meta.AddVersion(version.CreatedTime, nil, 1, attribution)
+		meta.AddVersion(version.CreatedTime, nil, 1)
 		err = b.writeKeyMetadata(ctx, s, meta)
 		if err != nil {
 			return err


### PR DESCRIPTION
# Overview

This PR populates the KeyMetadata struct with its field with the associated Request.ClientID if and only if the Request.EntityID is not already set.

# Design of Change

There's a bit of style cleanup here, but the logic is in `getAttribution(logical.Request)`. We basically just populate the ClientID and then clear it if the EntityID is already set for the request.

# Related Issues/Pull Requests
[X] https://hashicorp.atlassian.net/browse/VAULT-39432

# Contributor Checklist

Docs and Changelog to follow.

# PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
