### PR TITLE
Check for already upgraded mount on downstream nodes

### DIFF
--- a/upgrade.go
+++ b/upgrade.go
@@ -106,12 +106,12 @@ func (b *versionedKVBackend) Initialize(ctx context.Context, req *logical.Initia
 
 		go func() {
 			for {
-				time.Sleep(time.Second)
-
-				// If we failed because the context is closed we are
-				// shutting down. Close this go routine and set the upgrade
-				// flag back to 0 for good measure.
-				if ctx.Err() != nil {
+				select {
+				case <-time.After(time.Second):
+				case <-ctx.Done():
+					// If we failed because the context is closed we are
+					// shutting down. Close this go routine and set the upgrade
+					// flag back to 0 for good measure.
 					atomic.StoreUint32(b.upgrading, 0)
 					return
 				}

--- a/upgrade.go
+++ b/upgrade.go
@@ -104,6 +104,16 @@ func (b *versionedKVBackend) Initialize(ctx context.Context, req *logical.Initia
 	if b.perfSecondaryCheck() {
 		b.Logger().Info("upgrade not running on performance replication secondary or performance standby")
 
+		done, err := b.upgradeDone(ctx, s)
+		if err != nil {
+			b.Logger().Error("upgrading resulted in error", "error", err)
+		}
+
+		if done {
+			atomic.StoreUint32(b.upgrading, 0)
+			return nil
+		}
+
 		go func() {
 			for {
 				select {


### PR DESCRIPTION
# Overview
Now that https://github.com/hashicorp/vault-plugin-secrets-kv/pull/212 is here, we can be more optimistic on downstream (standby/secondary) nodes: rather than assume that initially the mount isn't upgraded, check to see, eliminating the need for client retries on newly created kvv2 mounts.

# Design of Change
How was this change implemented?

# Related Issues/Pull Requests
[ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)
[ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible
[ ] Changelog entry added. See [Updating the Changelog](https://github.com/hashicorp/vault-plugin-secrets-kv/blob/main/README.md#updating-the-changelog).

# PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
