### PR TITLE
Changes needed to make kv-v2 mounts usable in vault tests with synctest

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -104,7 +104,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 
 // VersionedKVFactory returns a new KVV2 backend as logical.Backend.
 func VersionedKVFactory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
-	upgradeCtx, upgradeCancelFunc := context.WithCancel(ctx)
+	upgradeCtx, upgradeCancelFunc := context.WithCancel(context.Background())
 
 	b := &versionedKVBackend{
 		upgrading:         new(uint32),

--- a/upgrade.go
+++ b/upgrade.go
@@ -94,8 +94,12 @@ func (b *versionedKVBackend) Upgrade(ctx context.Context, s logical.Storage) err
 		b.Logger().Info("upgrade not running on performance replication secondary or performance standby")
 
 		go func() {
+			ticker := time.NewTicker(time.Second)
 			for {
-				time.Sleep(time.Second)
+				select {
+				case <-ticker.C:
+				case <-ctx.Done():
+				}
 
 				// If we failed because the context is closed we are
 				// shutting down. Close this go routine and set the upgrade
@@ -142,9 +146,6 @@ func (b *versionedKVBackend) Upgrade(ctx context.Context, s logical.Storage) err
 	if err != nil {
 		return err
 	}
-
-	// Because this is a long-running process we need a new context.
-	ctx = context.Background()
 
 	upgradeKey := func(key string) error {
 		if strings.HasPrefix(key, b.storagePrefix) {
@@ -222,6 +223,7 @@ func (b *versionedKVBackend) Upgrade(ctx context.Context, s logical.Storage) err
 	}
 
 	writeUpgradeInfoDoneFunc := func(info []byte) {
+		ticker := time.NewTicker(10 * time.Millisecond)
 		for {
 			err = s.Put(ctx, &logical.StorageEntry{
 				Key:   path.Join(b.storagePrefix, "upgrading"),
@@ -231,7 +233,11 @@ func (b *versionedKVBackend) Upgrade(ctx context.Context, s logical.Storage) err
 			case err == nil:
 				return
 			case err.Error() == logical.ErrSetupReadOnly.Error():
-				time.Sleep(10 * time.Millisecond)
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+				}
 			default:
 				b.Logger().Error("writing upgrade info resulted in an error, but all keys were successfully upgraded", "error", err)
 				return
@@ -242,6 +248,7 @@ func (b *versionedKVBackend) Upgrade(ctx context.Context, s logical.Storage) err
 	upgradeFunc := func() {
 		// Write the canary value and if we are read only wait until the setup
 		// process has finished.
+		ticker := time.NewTicker(10 * time.Millisecond)
 	READONLY_LOOP:
 		for {
 			err := s.Put(ctx, &logical.StorageEntry{
@@ -252,7 +259,11 @@ func (b *versionedKVBackend) Upgrade(ctx context.Context, s logical.Storage) err
 			case err == nil:
 				break READONLY_LOOP
 			case err.Error() == logical.ErrSetupReadOnly.Error():
-				time.Sleep(10 * time.Millisecond)
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+				}
 			default:
 				b.Logger().Error("writing upgrade info resulted in an error", "error", err)
 				return


### PR DESCRIPTION

# Overview
Call Upgrade using a context.Background based ctx instead of the one passed into the factory.  This allows it to be cancelled by Cleanup.  Also use select with tickers instead of sleeps.  Together these changes make it possible to use kv mounts reliably in synctests with clusters.

# Design of Change
How was this change implemented?

# Related Issues/Pull Requests
[ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)
[ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible

# PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
